### PR TITLE
Version 1.5.6

### DIFF
--- a/SOURCES/defs/1.9.1-p378
+++ b/SOURCES/defs/1.9.1-p378
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:26 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:16 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2011-10-30
 eol(security): 2012-01-31
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.1-p378): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.1-p378" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.gz" "886f4fc22881cfc92d850e976c891d3f31832e31"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.1-p378" "https://ruby.kaos.io/ruby-1.9.1-p378.7z" "205975b4b83257909579176bfd05d5e353f95171"
   package: "rubygems-2.4.7" "https://ruby.kaos.io/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.1-p429
+++ b/SOURCES/defs/1.9.1-p429
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:26 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:16 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2011-10-30
 eol(security): 2012-01-31
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.1-p429): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.1-p429" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p429.tar.gz" "b7ed4e5c7f9f42895f0814d46043bb0714b69a43"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.1-p429" "https://ruby.kaos.io/ruby-1.9.1-p429.7z" "57f06cd6aa12dc30ae72eb9abb53ad10346320eb"
   package: "rubygems-2.4.7" "https://ruby.kaos.io/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.1-p430
+++ b/SOURCES/defs/1.9.1-p430
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:26 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:17 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2011-10-30
 eol(security): 2012-01-31
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.1-p430): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.1-p430" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p430.tar.gz" "51a3725c4b7f1b09b81dce0fe66dd6137cbc08f2"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.1-p430" "https://ruby.kaos.io/ruby-1.9.1-p430.7z" "8203ceed9ce8a0fe59802ee5b390656989755712"
   package: "rubygems-2.4.7" "https://ruby.kaos.io/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.1-p431
+++ b/SOURCES/defs/1.9.1-p431
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:26 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:17 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2011-10-30
 eol(security): 2012-01-31
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.1-p431): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.1-p431" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p431.tar.gz" "72d427eb67d0bf0d6071660ee8007760132a5109"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.1-p431" "https://ruby.kaos.io/ruby-1.9.1-p431.7z" "20e634519d5e29a957f95dbd4b642c01b6633d25"
   package: "rubygems-2.4.7" "https://ruby.kaos.io/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p180
+++ b/SOURCES/defs/1.9.2-p180
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:26 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:17 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,20 +10,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p180): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.2-p180" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz" "6a482bc07239b37bcadf68dda63c65d20dc19ebe"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.2-p180" "https://ruby.kaos.io/ruby-1.9.2-p180.7z" "7b158680aa89a30c4c462be5e5b7b34a5321ebb0"
   package: "rubygems-2.4.7" "https://ruby.kaos.io/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p180-railsexpress
+++ b/SOURCES/defs/1.9.2-p180-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:26 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:17 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,22 +10,22 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p180): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.2-p180.7z" "d2084a802808b06e2bc242cd42f341ed1376efb4"
   package: "ruby-1.9.2-p180" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz" "6a482bc07239b37bcadf68dda63c65d20dc19ebe"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.2-p180.7z" "d2084a802808b06e2bc242cd42f341ed1376efb4"
   package: "ruby-1.9.2-p180" "https://ruby.kaos.io/ruby-1.9.2-p180.7z" "7b158680aa89a30c4c462be5e5b7b34a5321ebb0"
   package: "rubygems-2.4.7" "https://ruby.kaos.io/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p290
+++ b/SOURCES/defs/1.9.2-p290
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:26 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:17 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,20 +10,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p290): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.2-p290" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz" "16fc9cf2223fc34821bc491fb3827f11cc5627ec"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.2-p290" "https://ruby.kaos.io/ruby-1.9.2-p290.7z" "8cc4ac91971a739ddcf13d03f95e1c3e1d818269"
   package: "rubygems-2.4.7" "https://ruby.kaos.io/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p290-railsexpress
+++ b/SOURCES/defs/1.9.2-p290-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:17 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,22 +10,22 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p290): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.2-p290.7z" "79615a1ac3f0136242f7740ff5efd2b2fdf46647"
   package: "ruby-1.9.2-p290" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz" "16fc9cf2223fc34821bc491fb3827f11cc5627ec"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.2-p290.7z" "79615a1ac3f0136242f7740ff5efd2b2fdf46647"
   package: "ruby-1.9.2-p290" "https://ruby.kaos.io/ruby-1.9.2-p290.7z" "8cc4ac91971a739ddcf13d03f95e1c3e1d818269"
   package: "rubygems-2.4.7" "https://ruby.kaos.io/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p318
+++ b/SOURCES/defs/1.9.2-p318
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:17 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,20 +10,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p318): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.2-p318" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.gz" "8402e3726bcf62b422b1e9dd8a425b8707dc4042"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.2-p318" "https://ruby.kaos.io/ruby-1.9.2-p318.7z" "9b643406f68718981c18f7cb06ffdacd03a87989"
   package: "rubygems-2.4.7" "https://ruby.kaos.io/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p318-railsexpress
+++ b/SOURCES/defs/1.9.2-p318-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:18 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,22 +10,22 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p318): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.2-p318.7z" "6b4a77ace72b3ebd954bbf7f794c0dc071ca753a"
   package: "ruby-1.9.2-p318" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.gz" "8402e3726bcf62b422b1e9dd8a425b8707dc4042"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.2-p318.7z" "6b4a77ace72b3ebd954bbf7f794c0dc071ca753a"
   package: "ruby-1.9.2-p318" "https://ruby.kaos.io/ruby-1.9.2-p318.7z" "9b643406f68718981c18f7cb06ffdacd03a87989"
   package: "rubygems-2.4.7" "https://ruby.kaos.io/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p320
+++ b/SOURCES/defs/1.9.2-p320
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:18 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,20 +10,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p320): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.2-p320" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.gz" "ead282bf780eb671a627e5e071f96c2fa4c64c1a"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.2-p320" "https://ruby.kaos.io/ruby-1.9.2-p320.7z" "8116af1baaa7dbdf8844371fcda84384d553eeeb"
   package: "rubygems-2.4.7" "https://ruby.kaos.io/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p320-railsexpress
+++ b/SOURCES/defs/1.9.2-p320-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:18 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,22 +10,22 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p320): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.2-p320.7z" "6b4a77ace72b3ebd954bbf7f794c0dc071ca753a"
   package: "ruby-1.9.2-p320" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.gz" "ead282bf780eb671a627e5e071f96c2fa4c64c1a"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.2-p320.7z" "6b4a77ace72b3ebd954bbf7f794c0dc071ca753a"
   package: "ruby-1.9.2-p320" "https://ruby.kaos.io/ruby-1.9.2-p320.7z" "8116af1baaa7dbdf8844371fcda84384d553eeeb"
   package: "rubygems-2.4.7" "https://ruby.kaos.io/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p330
+++ b/SOURCES/defs/1.9.2-p330
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:18 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,20 +10,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p330): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.2-p330" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz" "d25dca1adf186a1be7dcf12a48ea4c7abadfcf12"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.2-p330" "https://ruby.kaos.io/ruby-1.9.2-p330.7z" "adc44d5ce3a58043cd330a864c90c945f441c81b"
   package: "rubygems-2.4.7" "https://ruby.kaos.io/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.3-p0
+++ b/SOURCES/defs/1.9.3-p0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:18 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p0" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.gz" "f7cef9ad2808a1f522427c9116416973b9fcaf1a"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p0" "https://ruby.kaos.io/ruby-1.9.3-p0.7z" "01b91655f59b6b7bd493e5d4625fab46f0a1323c"

--- a/SOURCES/defs/1.9.3-p105
+++ b/SOURCES/defs/1.9.3-p105
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:18 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p105): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
   package: "ruby-1.9.3-p105" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p105.tar.gz" "9943afce862e28b7952af0cd4091b3e8d3358b1e"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p105" "https://ruby.kaos.io/ruby-1.9.3-p105.7z" "234c6eb697a766851deb487da07d929c2bf951d9"

--- a/SOURCES/defs/1.9.3-p125
+++ b/SOURCES/defs/1.9.3-p125
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:18 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev
 deps(deb): autoconf libc6-dev libncurses5-dev bison
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p125): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p125" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.gz" "3ea11df6bc4e7537cf97f7b134db24c55dfe013d"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p125" "https://ruby.kaos.io/ruby-1.9.3-p125.7z" "21d36dc5854e871be807d700c0de32c2a593262c"

--- a/SOURCES/defs/1.9.3-p125-railsexpress
+++ b/SOURCES/defs/1.9.3-p125-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:19 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p125): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p125.7z" "c3d5f4d9e080b3ed75c09b4fa77faef9bed0f295"
   package: "ruby-1.9.3-p125" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.gz" "3ea11df6bc4e7537cf97f7b134db24c55dfe013d"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p125.7z" "c3d5f4d9e080b3ed75c09b4fa77faef9bed0f295"
   package: "ruby-1.9.3-p125" "https://ruby.kaos.io/ruby-1.9.3-p125.7z" "21d36dc5854e871be807d700c0de32c2a593262c"

--- a/SOURCES/defs/1.9.3-p194
+++ b/SOURCES/defs/1.9.3-p194
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:19 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p194): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p194" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.gz" "" "31cf6bd981e4c929e5dc3bbdb341833eab1bd9f2"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p194" "https://ruby.kaos.io/ruby-1.9.3-p194.7z" "f7069a26d2bc0809f230a3aeec8d58e6b0dc138f"

--- a/SOURCES/defs/1.9.3-p194-railsexpress
+++ b/SOURCES/defs/1.9.3-p194-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:19 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p194): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p194.7z" "048ef9fcbfe27d056debcd7f4e88337116db7491"
   package: "ruby-1.9.3-p194" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.gz" "31cf6bd981e4c929e5dc3bbdb341833eab1bd9f2"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p194.7z" "048ef9fcbfe27d056debcd7f4e88337116db7491"
   package: "ruby-1.9.3-p194" "https://ruby.kaos.io/ruby-1.9.3-p194.7z" "f7069a26d2bc0809f230a3aeec8d58e6b0dc138f"

--- a/SOURCES/defs/1.9.3-p286
+++ b/SOURCES/defs/1.9.3-p286
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:19 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p286): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p286" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.gz" "baac543eafc1d95513489edc051ebbbcbe849122"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p286" "https://ruby.kaos.io/ruby-1.9.3-p286.7z" "5c51c5b3d8b88395ab74906487f83fd2b2009536"

--- a/SOURCES/defs/1.9.3-p286-railsexpress
+++ b/SOURCES/defs/1.9.3-p286-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:19 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p286): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p286.7z" "ae09b0663b3cd955760cf1108c481be8ac8731af"
   package: "ruby-1.9.3-p286" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.gz" "baac543eafc1d95513489edc051ebbbcbe849122"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p286.7z" "ae09b0663b3cd955760cf1108c481be8ac8731af"
   package: "ruby-1.9.3-p286" "https://ruby.kaos.io/ruby-1.9.3-p286.7z" "5c51c5b3d8b88395ab74906487f83fd2b2009536"

--- a/SOURCES/defs/1.9.3-p327
+++ b/SOURCES/defs/1.9.3-p327
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:19 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p327): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p327" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.gz" "a4075e5126278b5cba982d8c832dc03114e7a02a"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p327" "https://ruby.kaos.io/ruby-1.9.3-p327.7z" "4bb7bc626ffda34304308f7c38b786e6edec3920"

--- a/SOURCES/defs/1.9.3-p327-railsexpress
+++ b/SOURCES/defs/1.9.3-p327-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:19 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p327): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p327.7z" "fea2a3124d1f7c79a62b0ae52b379903e66ff202"
   package: "ruby-1.9.3-p327" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.gz" "a4075e5126278b5cba982d8c832dc03114e7a02a"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p327.7z" "fea2a3124d1f7c79a62b0ae52b379903e66ff202"
   package: "ruby-1.9.3-p327" "https://ruby.kaos.io/ruby-1.9.3-p327.7z" "4bb7bc626ffda34304308f7c38b786e6edec3920"

--- a/SOURCES/defs/1.9.3-p362
+++ b/SOURCES/defs/1.9.3-p362
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:20 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p362): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p362" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p362.tar.gz" "bd9866115b484eb92bf7283834af63a92191e250"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p362" "https://ruby.kaos.io/ruby-1.9.3-p362.7z" "ac597871a9c67219b2f1b0b48eb9c823ba114623"

--- a/SOURCES/defs/1.9.3-p362-railsexpress
+++ b/SOURCES/defs/1.9.3-p362-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:20 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p362): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p362.7z" "1c3078a668a47948a45d583edcaaf7f902b099c9"
   package: "ruby-1.9.3-p362" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p362.tar.gz" "bd9866115b484eb92bf7283834af63a92191e250"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p362.7z" "1c3078a668a47948a45d583edcaaf7f902b099c9"
   package: "ruby-1.9.3-p362" "https://ruby.kaos.io/ruby-1.9.3-p362.7z" "ac597871a9c67219b2f1b0b48eb9c823ba114623"

--- a/SOURCES/defs/1.9.3-p374
+++ b/SOURCES/defs/1.9.3-p374
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:27 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:20 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p374): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p374" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p374.tar.gz" "62ec444899de428461e8476c4bca62469b331333"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p374" "https://ruby.kaos.io/ruby-1.9.3-p374.7z" "dffb112edfe918aed5e77fa33688436ef138d589"

--- a/SOURCES/defs/1.9.3-p374-railsexpress
+++ b/SOURCES/defs/1.9.3-p374-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:20 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p374): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p374.7z" "69585dae98eb1ae3f7b7d95061b65aa116140179"
   package: "ruby-1.9.3-p374" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p374.tar.gz" "62ec444899de428461e8476c4bca62469b331333"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p374.7z" "69585dae98eb1ae3f7b7d95061b65aa116140179"
   package: "ruby-1.9.3-p374" "https://ruby.kaos.io/ruby-1.9.3-p374.7z" "dffb112edfe918aed5e77fa33688436ef138d589"

--- a/SOURCES/defs/1.9.3-p385
+++ b/SOURCES/defs/1.9.3-p385
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:20 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p385): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p385" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p385.tar.gz" "5f7e7e64ca5aedeb9720f9cd056bfe81ab029a94"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p385" "https://ruby.kaos.io/ruby-1.9.3-p385.7z" "e711406b489e54265cf3dcbe84c7a12d86ca201b"

--- a/SOURCES/defs/1.9.3-p385-railsexpress
+++ b/SOURCES/defs/1.9.3-p385-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:20 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p385): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p385.7z" "15224ff3ce5c846ef731aa326b5880c352b218c0"
   package: "ruby-1.9.3-p385" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p385.tar.gz" "5f7e7e64ca5aedeb9720f9cd056bfe81ab029a94"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p385.7z" "15224ff3ce5c846ef731aa326b5880c352b218c0"
   package: "ruby-1.9.3-p385" "https://ruby.kaos.io/ruby-1.9.3-p385.7z" "e711406b489e54265cf3dcbe84c7a12d86ca201b"

--- a/SOURCES/defs/1.9.3-p392
+++ b/SOURCES/defs/1.9.3-p392
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:20 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p392): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p392" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.gz" "ec75fcbd3b6b46ce6ec997ee4c86145b4abd5748"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p392" "https://ruby.kaos.io/ruby-1.9.3-p392.7z" "802fb0e66a5430f0bd69d0df8b635c466c2abc60"

--- a/SOURCES/defs/1.9.3-p392-railsexpress
+++ b/SOURCES/defs/1.9.3-p392-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:21 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p392): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p392.7z" "5ebfa470dbb266978d240e51a929925f35890534"
   package: "ruby-1.9.3-p392" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.gz" "ec75fcbd3b6b46ce6ec997ee4c86145b4abd5748"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p392.7z" "5ebfa470dbb266978d240e51a929925f35890534"
   package: "ruby-1.9.3-p392" "https://ruby.kaos.io/ruby-1.9.3-p392.7z" "802fb0e66a5430f0bd69d0df8b635c466c2abc60"

--- a/SOURCES/defs/1.9.3-p426
+++ b/SOURCES/defs/1.9.3-p426
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:21 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p426): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p426" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p426.tar.gz" "00ba5d9736d5783fbca93ef367d8861d20f2f768"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p426" "https://ruby.kaos.io/ruby-1.9.3-p426.7z" "258bdcecd3288212168734294647ca345d097d35"

--- a/SOURCES/defs/1.9.3-p429
+++ b/SOURCES/defs/1.9.3-p429
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:21 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p429): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p429" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz" "a1c3a25eb0720cb5f339343ad9605448089ff7cd"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p429" "https://ruby.kaos.io/ruby-1.9.3-p429.7z" "57ca27b8a7a158c70ee390e3c222d8e42da783b6"

--- a/SOURCES/defs/1.9.3-p429-railsexpress
+++ b/SOURCES/defs/1.9.3-p429-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:21 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p429): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p429.7z" "022d931daaf2389b9ba8572ac7aea26646e80e4f"
   package: "ruby-1.9.3-p429" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz" "a1c3a25eb0720cb5f339343ad9605448089ff7cd"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p429.7z" "022d931daaf2389b9ba8572ac7aea26646e80e4f"
   package: "ruby-1.9.3-p429" "https://ruby.kaos.io/ruby-1.9.3-p429.7z" "57ca27b8a7a158c70ee390e3c222d8e42da783b6"

--- a/SOURCES/defs/1.9.3-p448
+++ b/SOURCES/defs/1.9.3-p448
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:21 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p448): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p448" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.gz" "c7f736e3bc1ca1e6619a9121837dd0840aad77ce"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p448" "https://ruby.kaos.io/ruby-1.9.3-p448.7z" "db78c69e38ddb28a6d4e50dc9499baaa456a241d"

--- a/SOURCES/defs/1.9.3-p448-railsexpress
+++ b/SOURCES/defs/1.9.3-p448-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:21 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p448): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p448.7z" "5c85a19fde4155d9f1a512cd2f0923f4fe405e6d"
   package: "ruby-1.9.3-p448" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.gz" "c7f736e3bc1ca1e6619a9121837dd0840aad77ce"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p448.7z" "5c85a19fde4155d9f1a512cd2f0923f4fe405e6d"
   package: "ruby-1.9.3-p448" "https://ruby.kaos.io/ruby-1.9.3-p448.7z" "db78c69e38ddb28a6d4e50dc9499baaa456a241d"

--- a/SOURCES/defs/1.9.3-p484
+++ b/SOURCES/defs/1.9.3-p484
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:21 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p484): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p484" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.gz" "6ae80f424968b5ce661ee9b2bee1c21adc9ee67c"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p484" "https://ruby.kaos.io/ruby-1.9.3-p484.7z" "279f0f9140db387818e7acedf0f376979ec9650d"

--- a/SOURCES/defs/1.9.3-p484-railsexpress
+++ b/SOURCES/defs/1.9.3-p484-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:22 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p484): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p484.7z" "bf8001b618dd6c6a586b019a9bcedcf6bf55ae5a"
   package: "ruby-1.9.3-p484" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.gz" "6ae80f424968b5ce661ee9b2bee1c21adc9ee67c"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p484.7z" "bf8001b618dd6c6a586b019a9bcedcf6bf55ae5a"
   package: "ruby-1.9.3-p484" "https://ruby.kaos.io/ruby-1.9.3-p484.7z" "279f0f9140db387818e7acedf0f376979ec9650d"

--- a/SOURCES/defs/1.9.3-p545
+++ b/SOURCES/defs/1.9.3-p545
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:22 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p545): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p545" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.gz" "03455364740914e8d2dfd6421f681b3fb68a4313"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p545" "https://ruby.kaos.io/ruby-1.9.3-p545.7z" "19340fc7b2a1f877741e5dc3b7087a87c45fb1be"

--- a/SOURCES/defs/1.9.3-p545-railsexpress
+++ b/SOURCES/defs/1.9.3-p545-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:22 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p545): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p545.7z" "ad04b2e3ac62612f47448698c3dacd306c270393"
   package: "ruby-1.9.3-p545" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.gz" "03455364740914e8d2dfd6421f681b3fb68a4313"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p545.7z" "ad04b2e3ac62612f47448698c3dacd306c270393"
   package: "ruby-1.9.3-p545" "https://ruby.kaos.io/ruby-1.9.3-p545.7z" "19340fc7b2a1f877741e5dc3b7087a87c45fb1be"

--- a/SOURCES/defs/1.9.3-p547
+++ b/SOURCES/defs/1.9.3-p547
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:22 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p547): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p547" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p547.tar.gz" "01a792f972f5787ce526a1aad62976c56c93174b"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p547" "https://ruby.kaos.io/ruby-1.9.3-p547.7z" "4ef28181b3215576f05f7a1cffc022840577a1c2"

--- a/SOURCES/defs/1.9.3-p547-railsexpress
+++ b/SOURCES/defs/1.9.3-p547-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:22 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p547): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p547.7z" "46ef737bd4fe76184dabf88e999c364136f044ed"
   package: "ruby-1.9.3-p547" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p547.tar.gz" "01a792f972f5787ce526a1aad62976c56c93174b"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p547.7z" "46ef737bd4fe76184dabf88e999c364136f044ed"
   package: "ruby-1.9.3-p547" "https://ruby.kaos.io/ruby-1.9.3-p547.7z" "4ef28181b3215576f05f7a1cffc022840577a1c2"

--- a/SOURCES/defs/1.9.3-p551
+++ b/SOURCES/defs/1.9.3-p551
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:22 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p551): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-1.9.3-p551" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz" "5cf6c9383444163a3f753b50c35e441988189258"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-1.9.3-p551" "https://ruby.kaos.io/ruby-1.9.3-p551.7z" "89bb05d83db8199a61c1ebf9e9cbfa21615679dc"

--- a/SOURCES/defs/1.9.3-p551-railsexpress
+++ b/SOURCES/defs/1.9.3-p551-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:28 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:22 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p551): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p551.7z" "8b290c42a639db71471d2e42560099f6df6a9e99"
   package: "ruby-1.9.3-p551" "https://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz" "5cf6c9383444163a3f753b50c35e441988189258"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.io/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/1.9.3-p551.7z" "8b290c42a639db71471d2e42560099f6df6a9e99"
   package: "ruby-1.9.3-p551" "https://ruby.kaos.io/ruby-1.9.3-p551.7z" "89bb05d83db8199a61c1ebf9e9cbfa21615679dc"

--- a/SOURCES/defs/2.0.0-p0
+++ b/SOURCES/defs/2.0.0-p0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:29 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.0.0-p0" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.gz" "5349078b65fdeea85c7217d0ca98e718d3612df4"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.0.0-p0" "https://ruby.kaos.io/ruby-2.0.0-p0.7z" "ead446dd7f6a543d484abe38a4c7d4c8ba2714f3"

--- a/SOURCES/defs/2.0.0-p195
+++ b/SOURCES/defs/2.0.0-p195
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:29 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p195): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.0.0-p195" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.gz" "4935832c49d48e177dcf46d801faff29f11be811"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.0.0-p195" "https://ruby.kaos.io/ruby-2.0.0-p195.7z" "ac576370f0b997b3340f3897637e67d65b628315"

--- a/SOURCES/defs/2.0.0-p247
+++ b/SOURCES/defs/2.0.0-p247
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:29 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p247): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.0.0-p247" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz" "850b93afb5914ee3f38f0769e309abf0cedf084b"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.0.0-p247" "https://ruby.kaos.io/ruby-2.0.0-p247.7z" "d0d3604daf969ecbd20fbbf22911506aba91135c"

--- a/SOURCES/defs/2.0.0-p247-railsexpress
+++ b/SOURCES/defs/2.0.0-p247-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:29 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p247): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p247.7z" "ec00cba2b333f3ae65e0b3eede544b32d3e6c321"
   package: "ruby-2.0.0-p247" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz" "850b93afb5914ee3f38f0769e309abf0cedf084b"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p247.7z" "ec00cba2b333f3ae65e0b3eede544b32d3e6c321"
   package: "ruby-2.0.0-p247" "https://ruby.kaos.io/ruby-2.0.0-p247.7z" "d0d3604daf969ecbd20fbbf22911506aba91135c"

--- a/SOURCES/defs/2.0.0-p353
+++ b/SOURCES/defs/2.0.0-p353
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:29 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p353): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.0.0-p353" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.gz" "7f2c8b8f5682aabc1114f44d36d314c6c37c11b8"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.0.0-p353" "https://ruby.kaos.io/ruby-2.0.0-p353.7z" "f2ef3dee84776b9b88fec13ae9a8ecbfa1407643"

--- a/SOURCES/defs/2.0.0-p353-railsexpress
+++ b/SOURCES/defs/2.0.0-p353-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:29 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p353): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p353.7z" "1c4d00231d274cdaa6dab2dbea18184695206fa2"
   package: "ruby-2.0.0-p353" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.gz" "7f2c8b8f5682aabc1114f44d36d314c6c37c11b8"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p353.7z" "1c4d00231d274cdaa6dab2dbea18184695206fa2"
   package: "ruby-2.0.0-p353" "https://ruby.kaos.io/ruby-2.0.0-p353.7z" "f2ef3dee84776b9b88fec13ae9a8ecbfa1407643"

--- a/SOURCES/defs/2.0.0-p451
+++ b/SOURCES/defs/2.0.0-p451
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:29 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p451): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.0.0-p451" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.gz" "258adeba517c04f2c972736dece6c27ecea03432"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.0.0-p451" "https://ruby.kaos.io/ruby-2.0.0-p451.7z" "d10203f5affd6f23096fee3e0ed621b34d96c0a2"

--- a/SOURCES/defs/2.0.0-p451-railsexpress
+++ b/SOURCES/defs/2.0.0-p451-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:30 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p451): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p451.7z" "1e9bd7e88a229c54b82024f2e63e6e1c2fb9a830"
   package: "ruby-2.0.0-p451" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.gz" "258adeba517c04f2c972736dece6c27ecea03432"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p451.7z" "1e9bd7e88a229c54b82024f2e63e6e1c2fb9a830"
   package: "ruby-2.0.0-p451" "https://ruby.kaos.io/ruby-2.0.0-p451.7z" "d10203f5affd6f23096fee3e0ed621b34d96c0a2"

--- a/SOURCES/defs/2.0.0-p481
+++ b/SOURCES/defs/2.0.0-p481
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:30 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p481): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.0.0-p481" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.gz" "dded7b7349d59feb83d4f774b2ddec23eeab7978"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.0.0-p481" "https://ruby.kaos.io/ruby-2.0.0-p481.7z" "7c867d29a5db33dc9fa775f3d5c61b9eb4d15b50"

--- a/SOURCES/defs/2.0.0-p481-railsexpress
+++ b/SOURCES/defs/2.0.0-p481-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:30 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p481): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p481.7z" "6df4daed560a6e853e69648890a28aeaa6ed5c0a"
   package: "ruby-2.0.0-p481" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.gz" "dded7b7349d59feb83d4f774b2ddec23eeab7978"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p481.7z" "6df4daed560a6e853e69648890a28aeaa6ed5c0a"
   package: "ruby-2.0.0-p481" "https://ruby.kaos.io/ruby-2.0.0-p481.7z" "7c867d29a5db33dc9fa775f3d5c61b9eb4d15b50"

--- a/SOURCES/defs/2.0.0-p576
+++ b/SOURCES/defs/2.0.0-p576
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:30 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p576): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.0.0-p576" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.gz" "5bf54cbcc6c19729f85110d165eb90c702289662"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.0.0-p576" "https://ruby.kaos.io/ruby-2.0.0-p576.7z" "352a37ab7ffbefbed0e182c547222f71dd79150d"

--- a/SOURCES/defs/2.0.0-p594
+++ b/SOURCES/defs/2.0.0-p594
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:30 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p594): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.0.0-p594" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.gz" "d448fb9dde621a645f931a25a3addc4458e69d36"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.0.0-p594" "https://ruby.kaos.io/ruby-2.0.0-p594.7z" "d1e44ee16bcc09b636899c921fcbc2e6f0e65f11"

--- a/SOURCES/defs/2.0.0-p594-railsexpress
+++ b/SOURCES/defs/2.0.0-p594-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:30 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p594): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p594.7z" "5cbcba7b29a7f1a6ef8e222024b184c47712a9fc"
   package: "ruby-2.0.0-p594" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.gz" "d448fb9dde621a645f931a25a3addc4458e69d36"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p594.7z" "5cbcba7b29a7f1a6ef8e222024b184c47712a9fc"
   package: "ruby-2.0.0-p594" "https://ruby.kaos.io/ruby-2.0.0-p594.7z" "d1e44ee16bcc09b636899c921fcbc2e6f0e65f11"

--- a/SOURCES/defs/2.0.0-p598
+++ b/SOURCES/defs/2.0.0-p598
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:30 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p598): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.0.0-p598" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.gz" "2ef5e28b7ff0583f2f51ba498d317a86c71a5aa0"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.0.0-p598" "https://ruby.kaos.io/ruby-2.0.0-p598.7z" "bd6c9c797e5a456d62cd0361c67b9d92b7c0a649"

--- a/SOURCES/defs/2.0.0-p598-railsexpress
+++ b/SOURCES/defs/2.0.0-p598-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:31 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p598): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p598.7z" "5cbcba7b29a7f1a6ef8e222024b184c47712a9fc"
   package: "ruby-2.0.0-p598" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.gz" "2ef5e28b7ff0583f2f51ba498d317a86c71a5aa0"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p598.7z" "5cbcba7b29a7f1a6ef8e222024b184c47712a9fc"
   package: "ruby-2.0.0-p598" "https://ruby.kaos.io/ruby-2.0.0-p598.7z" "bd6c9c797e5a456d62cd0361c67b9d92b7c0a649"

--- a/SOURCES/defs/2.0.0-p643
+++ b/SOURCES/defs/2.0.0-p643
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:47 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:31 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p643): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.0.0-p643" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p643.tar.gz" "544840583939175886a0885bce1cf07f0b9550b7"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.0.0-p643" "https://ruby.kaos.io/ruby-2.0.0-p643.7z" "98ba5951fa83f4dc7539d349d1cb24bde4910efd"

--- a/SOURCES/defs/2.0.0-p645
+++ b/SOURCES/defs/2.0.0-p645
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:48 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:31 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p645): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.0.0-p645" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.gz" "4f922cda8d8f745f7b80cef8f79a0b51c252bbf5"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.0.0-p645" "https://ruby.kaos.io/ruby-2.0.0-p645.7z" "cc1b0d49ecc5ba3402d318c466138160eb0558ee"

--- a/SOURCES/defs/2.0.0-p645-railsexpress
+++ b/SOURCES/defs/2.0.0-p645-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:48 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:31 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p645): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p645.7z" "feb2cde1e2ba9d4c1ec33a1584b235ffe3fc2af5"
   package: "ruby-2.0.0-p645" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.gz" "4f922cda8d8f745f7b80cef8f79a0b51c252bbf5"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.0.0-p645.7z" "feb2cde1e2ba9d4c1ec33a1584b235ffe3fc2af5"
   package: "ruby-2.0.0-p645" "https://ruby.kaos.io/ruby-2.0.0-p645.7z" "cc1b0d49ecc5ba3402d318c466138160eb0558ee"

--- a/SOURCES/defs/2.0.0-p647
+++ b/SOURCES/defs/2.0.0-p647
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:48 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:31 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p647): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.0.0-p647" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.gz" "1d5f2748104cb1011d2888d5ca6ecdb3bee1115a"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.0.0-p647" "https://ruby.kaos.io/ruby-2.0.0-p647.7z" "3e4142ab809ebb4231c2b48b50ac3394996dbdc0"

--- a/SOURCES/defs/2.0.0-p647-railsexpress
+++ b/SOURCES/defs/2.0.0-p647-railsexpress
@@ -1,0 +1,26 @@
+# RBBuild Def File
+# UPDATED 13/Jul/2016 08:29:06 by Anton Novojlov <andy@essentialkaos.com>
+
+eol(normal): 2016-02-24
+eol(security): 2016-02-24
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
+
+CONFOPTS(ruby-2.0.0-p647): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
+  patchset: "https://ruby.kaos.io/patches/2.0.0-p647.7z" "7690490148f179ae39d7ca2f424b60b8dd83901f"
+  package: "ruby-2.0.0-p647" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.gz" "1d5f2748104cb1011d2888d5ca6ecdb3bee1115a"
+
+[essentialkaos]
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
+  patchset: "https://ruby.kaos.io/patches/2.0.0-p647.7z" "7690490148f179ae39d7ca2f424b60b8dd83901f"
+  package: "ruby-2.0.0-p647" "https://ruby.kaos.io/ruby-2.0.0-p647.7z" "3e4142ab809ebb4231c2b48b50ac3394996dbdc0"

--- a/SOURCES/defs/2.0.0-p648
+++ b/SOURCES/defs/2.0.0-p648
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:32:48 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:31 by Anton Novojlov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p648): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.0.0-p648" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.gz" "2323df55f5e941c45be13500df9daf216098f884"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.0.0-p648" "https://ruby.kaos.io/ruby-2.0.0-p648.7z" "a5e3644019650fe7e1a825a06a851ea65cae4aec"

--- a/SOURCES/defs/2.0.0-p648-railsexpress
+++ b/SOURCES/defs/2.0.0-p648-railsexpress
@@ -1,0 +1,26 @@
+# RBBuild Def File
+# UPDATED 13/Jul/2016 08:31:27 by Anton Novojlov <andy@essentialkaos.com>
+
+eol(normal): 2016-02-24
+eol(security): 2016-02-24
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
+
+CONFOPTS(ruby-2.0.0-p648): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
+  patchset: "https://ruby.kaos.io/patches/2.0.0-p648.7z" "7690490148f179ae39d7ca2f424b60b8dd83901f"
+  package: "ruby-2.0.0-p648" "https://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.gz" "2323df55f5e941c45be13500df9daf216098f884"
+
+[essentialkaos]
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
+  patchset: "https://ruby.kaos.io/patches/2.0.0-p648.7z" "7690490148f179ae39d7ca2f424b60b8dd83901f"
+  package: "ruby-2.0.0-p648" "https://ruby.kaos.io/ruby-2.0.0-p648.7z" "a5e3644019650fe7e1a825a06a851ea65cae4aec"

--- a/SOURCES/defs/2.1.0-p0
+++ b/SOURCES/defs/2.1.0-p0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:31 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.0-p0
+++ b/SOURCES/defs/2.1.0-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:19 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:31 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.1.0-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz" "99114e71c7765b5bdc0414c189a338f6f21fb51d"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.1.0-p0" "https://ruby.kaos.io/ruby-2.1.0.7z" "8d52bbc6f1513f458a34d4758071b600d16ced92"

--- a/SOURCES/defs/2.1.0-p0-railsexpress
+++ b/SOURCES/defs/2.1.0-p0-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:31 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.0-p0-railsexpress
+++ b/SOURCES/defs/2.1.0-p0-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:19 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:31 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.0-p0.7z" "967e93f451251f5821b4c2db9705f1a1b6904355"
   package: "ruby-2.1.0-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz" "99114e71c7765b5bdc0414c189a338f6f21fb51d"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.0-p0.7z" "967e93f451251f5821b4c2db9705f1a1b6904355"
   package: "ruby-2.1.0-p0" "https://ruby.kaos.io/ruby-2.1.0.7z" "8d52bbc6f1513f458a34d4758071b600d16ced92"

--- a/SOURCES/defs/2.1.1-p0
+++ b/SOURCES/defs/2.1.1-p0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.1-p0
+++ b/SOURCES/defs/2.1.1-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:20 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.1.1-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.gz" "27cbc8ae98863b4607ede8085beca2a20f4c03fd"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.1.1-p0" "https://ruby.kaos.io/ruby-2.1.1.7z" "c556e10c1130738613b3f7c7817db8c156daeb21"

--- a/SOURCES/defs/2.1.1-p0-railsexpress
+++ b/SOURCES/defs/2.1.1-p0-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.1-p0-railsexpress
+++ b/SOURCES/defs/2.1.1-p0-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:20 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.1-p0.7z" "f4dd7191e186bafa8ceb280da7279133a175ead8"
   package: "ruby-2.1.1-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.gz" "27cbc8ae98863b4607ede8085beca2a20f4c03fd"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.1-p0.7z" "f4dd7191e186bafa8ceb280da7279133a175ead8"
   package: "ruby-2.1.1-p0" "https://ruby.kaos.io/ruby-2.1.1.7z" "c556e10c1130738613b3f7c7817db8c156daeb21"

--- a/SOURCES/defs/2.1.10-p0
+++ b/SOURCES/defs/2.1.10-p0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.10-p0
+++ b/SOURCES/defs/2.1.10-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 12/May/2016 05:28:38 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.10-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.1.10-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.gz" "2a5194b1fd42a3f1f23f1e0844ae78332a9efd5d"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.1.10-p0" "https://ruby.kaos.io/ruby-2.1.10.7z" "30bd437feae430b0f77f8f9e6890c4784b25ba2d"

--- a/SOURCES/defs/2.1.2-p0
+++ b/SOURCES/defs/2.1.2-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:20 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.1.2-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz" "b818d56b4638f1949239038623b761517d4a5686"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.1.2-p0" "https://ruby.kaos.io/ruby-2.1.2.7z" "4a0e166f042b6c245af232a03235f42acbff290a"

--- a/SOURCES/defs/2.1.2-p0
+++ b/SOURCES/defs/2.1.2-p0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.2-p0-railsexpress
+++ b/SOURCES/defs/2.1.2-p0-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:20 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.2-p0.7z" "a94ea6c6d4234b1e56583204126c578db41538d9"
   package: "ruby-2.1.2-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz" "b818d56b4638f1949239038623b761517d4a5686"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.2-p0.7z" "a94ea6c6d4234b1e56583204126c578db41538d9"
   package: "ruby-2.1.2-p0" "https://ruby.kaos.io/ruby-2.1.2.7z" "4a0e166f042b6c245af232a03235f42acbff290a"

--- a/SOURCES/defs/2.1.2-p0-railsexpress
+++ b/SOURCES/defs/2.1.2-p0-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.3-p0
+++ b/SOURCES/defs/2.1.3-p0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.3-p0
+++ b/SOURCES/defs/2.1.3-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:20 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.1.3-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.gz" "ca6e120e5a2ee7deb3a7493696b5bbc28bfc2236"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.1.3-p0" "https://ruby.kaos.io/ruby-2.1.3.7z" "7d0f49c5347cf2125c4ce5f5661d896d496cd671"

--- a/SOURCES/defs/2.1.3-p0-railsexpress
+++ b/SOURCES/defs/2.1.3-p0-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.3-p0-railsexpress
+++ b/SOURCES/defs/2.1.3-p0-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:20 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:32 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.3-p0.7z" "2c2f4979b371a72c6a2af769fc77f7a71e0b0e61"
   package: "ruby-2.1.3-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.gz" "ca6e120e5a2ee7deb3a7493696b5bbc28bfc2236"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.3-p0.7z" "2c2f4979b371a72c6a2af769fc77f7a71e0b0e61"
   package: "ruby-2.1.3-p0" "https://ruby.kaos.io/ruby-2.1.3.7z" "7d0f49c5347cf2125c4ce5f5661d896d496cd671"

--- a/SOURCES/defs/2.1.4-p0
+++ b/SOURCES/defs/2.1.4-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:20 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.1.4-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.4.tar.gz" "29e9cfdd9e989b7621d7696ef3f970262a08dbc3"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.1.4-p0" "https://ruby.kaos.io/ruby-2.1.4.7z" "fc56ef8cf99cda9193ef3aa4376094a97644ec07"

--- a/SOURCES/defs/2.1.4-p0
+++ b/SOURCES/defs/2.1.4-p0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.4-p0-railsexpress
+++ b/SOURCES/defs/2.1.4-p0-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:20 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.4-p0.7z" "ecce83294f15d22b4029ff6f83ddd3b7fba91bd9"
   package: "ruby-2.1.4-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.4.tar.gz" "29e9cfdd9e989b7621d7696ef3f970262a08dbc3"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.4-p0.7z" "ecce83294f15d22b4029ff6f83ddd3b7fba91bd9"
   package: "ruby-2.1.4-p0" "https://ruby.kaos.io/ruby-2.1.4.7z" "fc56ef8cf99cda9193ef3aa4376094a97644ec07"

--- a/SOURCES/defs/2.1.4-p0-railsexpress
+++ b/SOURCES/defs/2.1.4-p0-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.5-p0
+++ b/SOURCES/defs/2.1.5-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:20 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.1.5-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz" "9c0a238bd7839a4b51871641945a3da90997b8c2"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.1.5-p0" "https://ruby.kaos.io/ruby-2.1.5.7z" "f3766dad3ec9e0092d05c4dcd07d88fd88754342"

--- a/SOURCES/defs/2.1.5-p0
+++ b/SOURCES/defs/2.1.5-p0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.5-p0-railsexpress
+++ b/SOURCES/defs/2.1.5-p0-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.5-p0-railsexpress
+++ b/SOURCES/defs/2.1.5-p0-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:20 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.5-p0.7z" "93cbf96603b1d3176b22943b64e104bb029de92d"
   package: "ruby-2.1.5-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz" "9c0a238bd7839a4b51871641945a3da90997b8c2"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.5-p0.7z" "93cbf96603b1d3176b22943b64e104bb029de92d"
   package: "ruby-2.1.5-p0" "https://ruby.kaos.io/ruby-2.1.5.7z" "f3766dad3ec9e0092d05c4dcd07d88fd88754342"

--- a/SOURCES/defs/2.1.6-p0
+++ b/SOURCES/defs/2.1.6-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:20 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.1.6-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz" "426289b6647ce35ad101091825b6e7e5fce207f3"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.1.6-p0" "https://ruby.kaos.io/ruby-2.1.6.7z" "01052beb4fa48e5a45d811cfcbdbe7313b0033af"

--- a/SOURCES/defs/2.1.6-p0
+++ b/SOURCES/defs/2.1.6-p0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.6-p0-railsexpress
+++ b/SOURCES/defs/2.1.6-p0-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.6-p0-railsexpress
+++ b/SOURCES/defs/2.1.6-p0-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:20 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.6-p0.7z" "f98b4f4e726ded11fbe1e4948e35aff49e4f0eca"
   package: "ruby-2.1.6-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz" "426289b6647ce35ad101091825b6e7e5fce207f3"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.1.6-p0.7z" "f98b4f4e726ded11fbe1e4948e35aff49e4f0eca"
   package: "ruby-2.1.6-p0" "https://ruby.kaos.io/ruby-2.1.6.7z" "01052beb4fa48e5a45d811cfcbdbe7313b0033af"

--- a/SOURCES/defs/2.1.7-p0
+++ b/SOURCES/defs/2.1.7-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:21 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.1.7-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.gz" "e2e195a4a58133e3ad33b955c829bb536fa3c075"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.1.7-p0" "https://ruby.kaos.io/ruby-2.1.7.7z" "d33f7460dd982e9ecbfe10e698ec470a2b226f1e"

--- a/SOURCES/defs/2.1.7-p0
+++ b/SOURCES/defs/2.1.7-p0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.7-p0-railsexpress
+++ b/SOURCES/defs/2.1.7-p0-railsexpress
@@ -1,0 +1,26 @@
+# RBBuild Def File
+# UPDATED 13/Jul/2016 17:12:30 by Anton Novojlov <andy@essentialkaos.com>
+
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
+
+CONFOPTS(ruby-2.1.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
+  patchset: "https://ruby.kaos.io/patches/2.1.7-p0.7z" "92fce7ffb6849878b01c4688678239446b4641a3"
+  package: "ruby-2.1.7-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.gz" "e2e195a4a58133e3ad33b955c829bb536fa3c075"
+
+[essentialkaos]
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
+  patchset: "https://ruby.kaos.io/patches/2.1.7-p0.7z" "92fce7ffb6849878b01c4688678239446b4641a3"
+  package: "ruby-2.1.7-p0" "https://ruby.kaos.io/ruby-2.1.7.7z" "d33f7460dd982e9ecbfe10e698ec470a2b226f1e"

--- a/SOURCES/defs/2.1.8-p0
+++ b/SOURCES/defs/2.1.8-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:21 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.8-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.1.8-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.gz" "c7e50159357afd87b13dc5eaf4ac486a70011149"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.1.8-p0" "https://ruby.kaos.io/ruby-2.1.8.7z" "217ae8854c0a42a419cff1c70ffda89f458767dd"

--- a/SOURCES/defs/2.1.8-p0
+++ b/SOURCES/defs/2.1.8-p0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:33 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.1.8-p0-railsexpress
+++ b/SOURCES/defs/2.1.8-p0-railsexpress
@@ -1,0 +1,26 @@
+# RBBuild Def File
+# UPDATED 13/Jul/2016 08:31:27 by Anton Novojlov <andy@essentialkaos.com>
+
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
+
+CONFOPTS(ruby-2.1.8-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
+  patchset: "https://ruby.kaos.io/patches/2.1.8-p0.7z" "2c1c813c00e164b84535a0b598e06d86cf326bef"
+  package: "ruby-2.1.8-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.gz" "c7e50159357afd87b13dc5eaf4ac486a70011149"
+
+[essentialkaos]
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
+  patchset: "https://ruby.kaos.io/patches/2.1.8-p0.7z" "2c1c813c00e164b84535a0b598e06d86cf326bef"
+  package: "ruby-2.1.8-p0" "https://ruby.kaos.io/ruby-2.1.8.7z" "217ae8854c0a42a419cff1c70ffda89f458767dd"

--- a/SOURCES/defs/2.1.9-p0
+++ b/SOURCES/defs/2.1.9-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 12/May/2016 05:28:38 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:34 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.9-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.1.9-p0" "https://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.gz" "dd68afc652fe542f83a9a709a74f4da2662054bf"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.1.9-p0" "https://ruby.kaos.io/ruby-2.1.9.7z" "9eccf2beb2b3559165c70e16e6612b97da403e7f"

--- a/SOURCES/defs/2.1.9-p0
+++ b/SOURCES/defs/2.1.9-p0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 13/Jul/2016 08:10:34 by Anton Novojlov <andy@essentialkaos.com>
 
+eol(normal): 2016-03-31
+eol(security): 2016-09-30
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.2.0-p0
+++ b/SOURCES/defs/2.2.0-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:21 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:34 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.2.0-p0" "https://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz" "680302104b24f850fddfe93ee37396de01765b37"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.2.0-p0" "https://ruby.kaos.io/ruby-2.2.0.7z" "0dc3c4b4f4d05368c1c38876b7d5b4e3238cc6f5"

--- a/SOURCES/defs/2.2.0-p0-railsexpress
+++ b/SOURCES/defs/2.2.0-p0-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:21 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:34 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.2.0-p0.7z" "fe7402810387b5744b1552bd73cf55992e0434b1"
   package: "ruby-2.2.0-p0" "https://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz" "680302104b24f850fddfe93ee37396de01765b37"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.2.0-p0.7z" "fe7402810387b5744b1552bd73cf55992e0434b1"
   package: "ruby-2.2.0-p0" "https://ruby.kaos.io/ruby-2.2.0.7z" "0dc3c4b4f4d05368c1c38876b7d5b4e3238cc6f5"

--- a/SOURCES/defs/2.2.1-p0
+++ b/SOURCES/defs/2.2.1-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:21 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:34 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.2.1-p0" "https://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.1.tar.gz" "12376b79163e02bc9bd1a39329d67c3d19ccace9"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.2.1-p0" "https://ruby.kaos.io/ruby-2.2.1.7z" "c9f8ef5fbdfdef9a334db4c02ba8cdea70af8d62"

--- a/SOURCES/defs/2.2.1-p0-railsexpress
+++ b/SOURCES/defs/2.2.1-p0-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:21 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:34 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.2.1-p0.7z" "d85ada041b9e27aac8ce4e900fd907b37f237155"
   package: "ruby-2.2.1-p0" "https://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.1.tar.gz" "12376b79163e02bc9bd1a39329d67c3d19ccace9"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.2.1-p0.7z" "d85ada041b9e27aac8ce4e900fd907b37f237155"
   package: "ruby-2.2.1-p0" "https://ruby.kaos.io/ruby-2.2.1.7z" "c9f8ef5fbdfdef9a334db4c02ba8cdea70af8d62"

--- a/SOURCES/defs/2.2.2-p0
+++ b/SOURCES/defs/2.2.2-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:21 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:34 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.2.2-p0" "https://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.gz" "29c51a17639d921b1ae51cd80a9d7584f67d5e1c"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.2.2-p0" "https://ruby.kaos.io/ruby-2.2.2.7z" "dce4ef96026f0a23bdf0265c66381edfe5b791a0"

--- a/SOURCES/defs/2.2.2-p0-railsexpress
+++ b/SOURCES/defs/2.2.2-p0-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:21 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:34 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   patchset: "https://ruby.kaos.io/patches/2.2.2-p0.7z" "d85ada041b9e27aac8ce4e900fd907b37f237155"
   package: "ruby-2.2.2-p0" "https://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.gz" "29c51a17639d921b1ae51cd80a9d7584f67d5e1c"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   patchset: "https://ruby.kaos.io/patches/2.2.2-p0.7z" "d85ada041b9e27aac8ce4e900fd907b37f237155"
   package: "ruby-2.2.2-p0" "https://ruby.kaos.io/ruby-2.2.2.7z" "dce4ef96026f0a23bdf0265c66381edfe5b791a0"

--- a/SOURCES/defs/2.2.3-p0
+++ b/SOURCES/defs/2.2.3-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:21 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:35 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.2.3-p0" "https://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz" "0d9e158534cb31e72740138b8f697b57b448e5c3"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.2.3-p0" "https://ruby.kaos.io/ruby-2.2.3.7z" "d4d3fae33cc3384e0c50a11c0d1df37426063e87"

--- a/SOURCES/defs/2.2.3-p0-railsexpress
+++ b/SOURCES/defs/2.2.3-p0-railsexpress
@@ -1,0 +1,23 @@
+# RBBuild Def File
+# UPDATED 13/Jul/2016 08:31:28 by Anton Novojlov <andy@essentialkaos.com>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
+
+CONFOPTS(ruby-2.2.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
+  patchset: "https://ruby.kaos.io/patches/2.2.3-p0.7z" "5c07e5ecfbda876cf5dba4c5e17e85957f21eb42"
+  package: "ruby-2.2.3-p0" "https://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz" "0d9e158534cb31e72740138b8f697b57b448e5c3"
+
+[essentialkaos]
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
+  patchset: "https://ruby.kaos.io/patches/2.2.3-p0.7z" "5c07e5ecfbda876cf5dba4c5e17e85957f21eb42"
+  package: "ruby-2.2.3-p0" "https://ruby.kaos.io/ruby-2.2.3.7z" "d4d3fae33cc3384e0c50a11c0d1df37426063e87"

--- a/SOURCES/defs/2.2.4-p0
+++ b/SOURCES/defs/2.2.4-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:21 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:35 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.2.4-p0" "https://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.gz" "818e5e157f76d4912ba3a7c7b4fc5156105e83c3"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.2.4-p0" "https://ruby.kaos.io/ruby-2.2.4.7z" "634e7accad66f852537efccfe63cd6bdd554a19a"

--- a/SOURCES/defs/2.2.4-p0-railsexpress
+++ b/SOURCES/defs/2.2.4-p0-railsexpress
@@ -1,0 +1,23 @@
+# RBBuild Def File
+# UPDATED 13/Jul/2016 08:31:28 by Anton Novojlov <andy@essentialkaos.com>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
+
+CONFOPTS(ruby-2.2.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
+  patchset: "https://ruby.kaos.io/patches/2.2.4-p0.7z" "3035ba413a8c9fd41408ea7a02f6722096721886"
+  package: "ruby-2.2.4-p0" "https://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.gz" "818e5e157f76d4912ba3a7c7b4fc5156105e83c3"
+
+[essentialkaos]
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
+  patchset: "https://ruby.kaos.io/patches/2.2.4-p0.7z" "3035ba413a8c9fd41408ea7a02f6722096721886"
+  package: "ruby-2.2.4-p0" "https://ruby.kaos.io/ruby-2.2.4.7z" "634e7accad66f852537efccfe63cd6bdd554a19a"

--- a/SOURCES/defs/2.2.5-p0
+++ b/SOURCES/defs/2.2.5-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 12/May/2016 05:28:38 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:35 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.2.5-p0" "https://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz" "457707459827bd527347a5cee7b4dc509b486713"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.2.5-p0" "https://ruby.kaos.io/ruby-2.2.5.7z" "cc5bbac25a417eb0594f3bbe6cea92f252fc3c90"

--- a/SOURCES/defs/2.2.5-p0-railsexpress
+++ b/SOURCES/defs/2.2.5-p0-railsexpress
@@ -1,0 +1,23 @@
+# RBBuild Def File
+# UPDATED 13/Jul/2016 08:31:29 by Anton Novojlov <andy@essentialkaos.com>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
+
+CONFOPTS(ruby-2.2.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
+  patchset: "https://ruby.kaos.io/patches/2.2.5-p0.7z" "0cd436aa96c04483a0938fba9b589ace5205a1bf"
+  package: "ruby-2.2.5-p0" "https://ftp.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz" "457707459827bd527347a5cee7b4dc509b486713"
+
+[essentialkaos]
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
+  patchset: "https://ruby.kaos.io/patches/2.2.5-p0.7z" "0cd436aa96c04483a0938fba9b589ace5205a1bf"
+  package: "ruby-2.2.5-p0" "https://ruby.kaos.io/ruby-2.2.5.7z" "cc5bbac25a417eb0594f3bbe6cea92f252fc3c90"

--- a/SOURCES/defs/2.3.0-p0
+++ b/SOURCES/defs/2.3.0-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:21 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:35 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "d2cfa980ef4548da6079fa1e51fe1fb2e5a53e99" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.3.0-p0" "https://ftp.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.gz" "2dfcf7f33bda4078efca30ae28cb89cd0e36ddc4"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.3.0-p0" "https://ruby.kaos.io/ruby-2.3.0.7z" "a60267b5b575ce1275518987418d9c66d7ae937e"

--- a/SOURCES/defs/2.3.0-p0-railsexpress
+++ b/SOURCES/defs/2.3.0-p0-railsexpress
@@ -1,0 +1,23 @@
+# RBBuild Def File
+# UPDATED 13/Jul/2016 08:31:29 by Anton Novojlov <andy@essentialkaos.com>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
+
+CONFOPTS(ruby-2.3.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
+  patchset: "https://ruby.kaos.io/patches/2.3.0-p0.7z" "5b1bb4459c0a88bf7752f2ea190b9e937f67f79b"
+  package: "ruby-2.3.0-p0" "https://ftp.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.gz" "2dfcf7f33bda4078efca30ae28cb89cd0e36ddc4"
+
+[essentialkaos]
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
+  patchset: "https://ruby.kaos.io/patches/2.3.0-p0.7z" "5b1bb4459c0a88bf7752f2ea190b9e937f67f79b"
+  package: "ruby-2.3.0-p0" "https://ruby.kaos.io/ruby-2.3.0.7z" "a60267b5b575ce1275518987418d9c66d7ae937e"

--- a/SOURCES/defs/2.3.1-p0
+++ b/SOURCES/defs/2.3.1-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 12/May/2016 05:12:10 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:35 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "d2cfa980ef4548da6079fa1e51fe1fb2e5a53e99" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.3.1-p0" "https://ftp.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz" "c39b4001f7acb4e334cb60a0f4df72d434bef711"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.3.1-p0" "https://ruby.kaos.io/ruby-2.3.1.7z" "5fb212c92c1e68099f7fa3d6eb8ced053ee4af5b"

--- a/SOURCES/defs/2.3.1-p0-railsexpress
+++ b/SOURCES/defs/2.3.1-p0-railsexpress
@@ -1,0 +1,23 @@
+# RBBuild Def File
+# UPDATED 13/Jul/2016 08:31:29 by Anton Novojlov <andy@essentialkaos.com>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
+
+CONFOPTS(ruby-2.3.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
+  patchset: "https://ruby.kaos.io/patches/2.3.1-p0.7z" "e2399f4df9b67ca143594a8aa82962c0567abe56"
+  package: "ruby-2.3.1-p0" "https://ftp.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz" "c39b4001f7acb4e334cb60a0f4df72d434bef711"
+
+[essentialkaos]
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
+  patchset: "https://ruby.kaos.io/patches/2.3.1-p0.7z" "e2399f4df9b67ca143594a8aa82962c0567abe56"
+  package: "ruby-2.3.1-p0" "https://ruby.kaos.io/ruby-2.3.1.7z" "5fb212c92c1e68099f7fa3d6eb8ced053ee4af5b"

--- a/SOURCES/defs/2.4.0-dev
+++ b/SOURCES/defs/2.4.0-dev
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 29/Feb/2016 19:20:21 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:35 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make ruby zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make ruby zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.0-dev): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "9d1977cc89242cd11471269ece2ed4650947c046" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
 git: "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "!" "trunk" "autoconf"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
 git: "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "!" "trunk" "autoconf"

--- a/SOURCES/defs/2.4.0-preview1
+++ b/SOURCES/defs/2.4.0-preview1
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 13/Jul/2016 08:10:35 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 09:36:01 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -10,12 +10,12 @@ CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl 
 MAKEOPTS(openssl-1.0.1t): -j 1
 PREFIX(openssl-1.0.1t): {prefix}/openssl
 
-CONFOPTS(ruby-2.3.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+CONFOPTS(ruby-2.4.0-preview1): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
   package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
-  package: "ruby-2.3.1-p0" "https://ftp.ruby-lang.org/pub/ruby/ruby-2.4.0-preview1.tar.gz" "1003a1e57547d81f4bb979c0f40f242afc284cd5"
+  package: "ruby-2.4.0-preview1" "https://ftp.ruby-lang.org/pub/ruby/ruby-2.4.0-preview1.tar.gz" "1003a1e57547d81f4bb979c0f40f242afc284cd5"
 
 [essentialkaos]
   package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
-  package: "ruby-2.3.1-p0" "https://ruby.kaos.io/ruby-2.4.0-preview1.7z" "ed7df3cd98fe301726325189527c376175d197ce"
+  package: "ruby-2.4.0-preview1" "https://ruby.kaos.io/ruby-2.4.0-preview1.7z" "ed7df3cd98fe301726325189527c376175d197ce"

--- a/SOURCES/defs/2.4.0-preview1-p0
+++ b/SOURCES/defs/2.4.0-preview1-p0
@@ -1,0 +1,21 @@
+# RBBuild Def File
+# UPDATED 13/Jul/2016 08:02:40 by Anton Novojlov <andy@essentialkaos.com>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1r): -j 1
+PREFIX(openssl-1.0.1r): {prefix}/openssl
+
+CONFOPTS(ruby-2.3.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "d2cfa980ef4548da6079fa1e51fe1fb2e5a53e99" openssl
+  package: "ruby-2.3.1-p0" "https://ftp.ruby-lang.org/pub/ruby/ruby-2.4.0-preview1.tar.gz" "1003a1e57547d81f4bb979c0f40f242afc284cd5"
+
+[essentialkaos]
+  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "ruby-2.3.1-p0" "https://ruby.kaos.io/ruby-2.4.0-preview1.7z" "ed7df3cd98fe301726325189527c376175d197ce"

--- a/SOURCES/defs/2.4.0-preview1-p0
+++ b/SOURCES/defs/2.4.0-preview1-p0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 13/Jul/2016 08:02:40 by Anton Novojlov <andy@essentialkaos.com>
+# UPDATED 13/Jul/2016 08:10:35 by Anton Novojlov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.1r): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
-MAKEOPTS(openssl-1.0.1r): -j 1
-PREFIX(openssl-1.0.1r): {prefix}/openssl
+CONFOPTS(openssl-1.0.1t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-krb5 shared
+MAKEOPTS(openssl-1.0.1t): -j 1
+PREFIX(openssl-1.0.1t): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.1r" "https://www.openssl.org/source/openssl-1.0.1r.tar.gz" "d2cfa980ef4548da6079fa1e51fe1fb2e5a53e99" openssl
+  package: "openssl-1.0.1t" "https://www.openssl.org/source/openssl-1.0.1t.tar.gz" "a684ba59d6721a90f354b1953e19611646be7e7d" openssl
   package: "ruby-2.3.1-p0" "https://ftp.ruby-lang.org/pub/ruby/ruby-2.4.0-preview1.tar.gz" "1003a1e57547d81f4bb979c0f40f242afc284cd5"
 
 [essentialkaos]
-  package: "openssl-1.0.1r" "https://ruby.kaos.io/openssl-1.0.1r.7z" "fa6a5a8dfe0f694136477c977a59708a993961e6" openssl
+  package: "openssl-1.0.1t" "https://ruby.kaos.io/openssl-1.0.1t.7z" "cb68a723e4663403dcea43aa49e4109bd791ba3f" openssl
   package: "ruby-2.3.1-p0" "https://ruby.kaos.io/ruby-2.4.0-preview1.7z" "ed7df3cd98fe301726325189527c376175d197ce"

--- a/SOURCES/defs/jruby-9.1.1.0
+++ b/SOURCES/defs/jruby-9.1.1.0
@@ -1,0 +1,12 @@
+# RBBuild Def File
+# UPDATED 13/Jul/2016 07:57:32 by Anton Novojlov <andy@essentialkaos.com>
+
+deps(rpm): make gcc gcc-c++
+deps(deb): make gcc build-essentials
+deps(bin): java
+
+[default]
+  package: "jruby-9.1.1.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.1.0/jruby-bin-9.1.1.0.tar.gz" "a3315e916a499da04c009eec2186585278f09d11" jruby
+
+[essentialkaos]
+  package: "jruby-9.1.1.0" "https://ruby.kaos.io/jruby-9.1.1.0.7z" "fbb8d94b4e153c5d69850cf3275bffa6525aa288" jruby

--- a/SOURCES/defs/jruby-9.1.2.0
+++ b/SOURCES/defs/jruby-9.1.2.0
@@ -1,0 +1,12 @@
+# RBBuild Def File
+# UPDATED 13/Jul/2016 07:57:33 by Anton Novojlov <andy@essentialkaos.com>
+
+deps(rpm): make gcc gcc-c++
+deps(deb): make gcc build-essentials
+deps(bin): java
+
+[default]
+  package: "jruby-9.1.2.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.2.0/jruby-bin-9.1.2.0.tar.gz" "c04f347d620aded0b8df59e0407448f02b1e901f" jruby
+
+[essentialkaos]
+  package: "jruby-9.1.2.0" "https://ruby.kaos.io/jruby-9.1.2.0.7z" "0d8844fda5e54430759a8171a551ceb0543a2015" jruby

--- a/SOURCES/rbbuild
+++ b/SOURCES/rbbuild
@@ -6,7 +6,7 @@
 APP="RBBuild"
 
 # App version (String)
-VER="1.5.5"
+VER="1.5.6"
 
 ################################################################################
 
@@ -1393,15 +1393,13 @@ listDefs() {
   for def in $all_list ; do
     [[ -h $defs_dir/$def ]] && continue
 
-    if [[ $def =~ (1|2).[0-9]{1,}.[0-9]{1,}-p[0-9]{1,} ]] ; then
+    if [[ $def =~ ^(1|2).[0-9]{1,}.[0-9]{1,}* ]] ; then
       ruby_list+=($def)
-    elif [[ $def =~ (1|2).[0-9]{1,}.[0-9]{1,}-dev ]] ; then
-      ruby_list+=($def)
-    elif [[ $def =~ jruby-* ]] ; then
+    elif [[ $def =~ ^jruby-* ]] ; then
       jruby_list+=($def)
-    elif [[ $def =~ ree-* ]] ; then
+    elif [[ $def =~ ^ree-* ]] ; then
       ree_list+=($def)
-    elif [[ $def =~ rubinius-* ]] ; then
+    elif [[ $def =~ ^rubinius-* ]] ; then
       rbx_list+=($def)
     else
       oth_list+=($def)

--- a/SOURCES/rbbuild
+++ b/SOURCES/rbbuild
@@ -1482,7 +1482,7 @@ getRBEnvPrefix() {
   fi
 }
 
-# Get recomended number of threads for build
+# Get recommended number of threads for build
 #
 # Code: No
 # Echo: Number of threads (Number)

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -29,7 +29,7 @@
 
 Summary:         Def files for rbbuild utility 
 Name:            rbbuild-defs
-Version:         1.5.20
+Version:         1.5.21
 Release:         0%{?dist}
 License:         EKOL
 Vendor:          ESSENTIALKAOS
@@ -75,6 +75,12 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Jul 13 2016 Anton Novojilov <andy@essentialkaos.com> - 1.5.21-0
+- Added 2.4.0-preview1
+- Added jruby-9.1.1.0
+- Added jruby-9.1.2.0
+- OpenSSL updated to 1.0.1t
+
 * Thu May 12 2016 Anton Novojilov <andy@essentialkaos.com> - 1.5.20-0
 - Added 2.3.1-p0
 - Added 2.2.5-p0

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -80,6 +80,7 @@ rm -rf %{buildroot}
 - Added jruby-9.1.1.0
 - Added jruby-9.1.2.0
 - OpenSSL updated to 1.0.1t
+- Added EOL dates for 2.1.x
 
 * Thu May 12 2016 Anton Novojilov <andy@essentialkaos.com> - 1.5.20-0
 - Added 2.3.1-p0

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -81,6 +81,7 @@ rm -rf %{buildroot}
 - Added jruby-9.1.2.0
 - Added 2.0.0-p647-railsexpress
 - Added 2.0.0-p648-railsexpress
+- Added 2.1.7-p0-railsexpress
 - Added 2.1.8-p0-railsexpress
 - Added 2.2.3-p0-railsexpress
 - Added 2.2.4-p0-railsexpress

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -34,7 +34,7 @@ Release:         0%{?dist}
 License:         EKOL
 Vendor:          ESSENTIALKAOS
 Group:           Development/Tools
-URL:             http://essentialkaos.com
+URL:             https://github.com/essentialkaos/rbbuild
 
 Source0:         %{name}-%{version}.tar.bz2
 

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -79,6 +79,14 @@ rm -rf %{buildroot}
 - Added 2.4.0-preview1
 - Added jruby-9.1.1.0
 - Added jruby-9.1.2.0
+- Added 2.0.0-p647-railsexpress
+- Added 2.0.0-p648-railsexpress
+- Added 2.1.8-p0-railsexpress
+- Added 2.2.3-p0-railsexpress
+- Added 2.2.4-p0-railsexpress
+- Added 2.2.5-p0-railsexpress
+- Added 2.3.0-p0-railsexpress
+- Added 2.3.1-p0-railsexpress
 - OpenSSL updated to 1.0.1t
 - Added EOL dates for 2.1.x
 

--- a/rbbuild.spec
+++ b/rbbuild.spec
@@ -34,7 +34,7 @@ Release:         0%{?dist}
 License:         EKOL
 Vendor:          ESSENTIALKAOS
 Group:           Development/Tools
-URL:             http://essentialkaos.com
+URL:             https://github.com/essentialkaos/rbbuild
 
 Source0:         https://source.kaos.io/%{name}/%{name}-%{version}.tar.bz2
 

--- a/rbbuild.spec
+++ b/rbbuild.spec
@@ -29,7 +29,7 @@
 
 Summary:         Utility for compiling and installing different ruby versions 
 Name:            rbbuild
-Version:         1.5.5
+Version:         1.5.6
 Release:         0%{?dist}
 License:         EKOL
 Vendor:          ESSENTIALKAOS
@@ -82,6 +82,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Jul 13 2016 Anton Novojilov <andy@essentialkaos.com> - 1.5.6-0
+- Imporved listing
+
 * Fri May 13 2016 Anton Novojilov <andy@essentialkaos.com> - 1.5.5-0
 - Fixed bug with listing def files
 - Imporved listing

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,9 @@
 
 `rbbuild` is utility for compiling and installing different ruby versions.
 
-### Installation
+[Installation](#installation) • [Build Status](#build-status) • [License](#license)
+
+## Installation
 
 #### From ESSENTIAL KAOS Public repo for RHEL6/CentOS6
 
@@ -30,7 +32,7 @@ If you have some issues with installing, try to use script in debug mode:
 sudo ./install.sh --debug
 ```
 
-### Usage
+#### Usage
 
 ```
 Usage: rbbuild <definition-file> <options>...
@@ -71,13 +73,13 @@ Examples:
   rbbuild 1.9.3
 ```
 
-### Build Status
+## Build Status
 
 | Branch | Status |
 |------------|--------|
 | `master` | [![Build Status](https://travis-ci.org/essentialkaos/rbbuild.svg?branch=master)](https://travis-ci.org/essentialkaos/rbbuild) |
 | `develop` | [![Build Status](https://travis-ci.org/essentialkaos/rbbuild.svg?branch=develop)](https://travis-ci.org/essentialkaos/rbbuild) |
 
-### License
+## License
 
 [EKOL](https://essentialkaos.com/ekol)

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,17 @@
-### RBBuild
+![RBBuild Logo](https://essentialkaos.com/github/rbbuild-v1.png)
 
 `rbbuild` is utility for compiling and installing different ruby versions.
 
-#### Installation
+### Installation
 
-###### From ESSENTIAL KAOS Public repo for RHEL6/CentOS6
+#### From ESSENTIAL KAOS Public repo for RHEL6/CentOS6
 
 ```
 yum install -y http://release.yum.kaos.io/i386/kaos-repo-6.8-0.el6.noarch.rpm
 yum install rbbuild
 ```
 
-###### Using install.sh
+#### Using install.sh
 
 We provide simple bash script `script.sh` for installing app from the sources.
 
@@ -30,7 +30,7 @@ If you have some issues with installing, try to use script in debug mode:
 sudo ./install.sh --debug
 ```
 
-#### Usage
+### Usage
 
 ```
 Usage: rbbuild <definition-file> <options>...
@@ -71,13 +71,13 @@ Examples:
   rbbuild 1.9.3
 ```
 
-#### Build Status
+### Build Status
 
-| Repository | Status |
+| Branch | Status |
 |------------|--------|
-| Stable | [![Build Status](https://travis-ci.org/essentialkaos/rbbuild.svg?branch=master)](https://travis-ci.org/essentialkaos/rbbuild) |
-| Unstable | [![Build Status](https://travis-ci.org/essentialkaos/rbbuild.svg?branch=develop)](https://travis-ci.org/essentialkaos/rbbuild) |
+| `master` | [![Build Status](https://travis-ci.org/essentialkaos/rbbuild.svg?branch=master)](https://travis-ci.org/essentialkaos/rbbuild) |
+| `develop` | [![Build Status](https://travis-ci.org/essentialkaos/rbbuild.svg?branch=develop)](https://travis-ci.org/essentialkaos/rbbuild) |
 
-#### License
+### License
 
 [EKOL](https://essentialkaos.com/ekol)

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 `rbbuild` is utility for compiling and installing different ruby versions.
 
-[Installation](#installation) • [Build Status](#build-status) • [License](#license)
+[Installation](#installation) • [Usage](#usage) • [Build Status](#build-status) • [License](#license)
 
 ## Installation
 
@@ -32,7 +32,7 @@ If you have some issues with installing, try to use script in debug mode:
 sudo ./install.sh --debug
 ```
 
-#### Usage
+## Usage
 
 ```
 Usage: rbbuild <definition-file> <options>...


### PR DESCRIPTION
* Improved listing
* Added `2.4.0-preview1`
* Added `jruby-9.1.1.0`
* Added `jruby-9.1.2.0`
* Added `2.0.0-p647-railsexpress`
* Added `2.0.0-p648-railsexpress`
* Added `2.1.8-p0-railsexpress`
* Added `2.2.3-p0-railsexpress`
* Added `2.2.4-p0-railsexpress`
* Added `2.2.5-p0-railsexpress`
* Added `2.3.0-p0-railsexpress`
* Added `2.3.1-p0-railsexpress`
* OpenSSL updated to 1.0.1t
* Added [EOL dates](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/) for 2.1.x
* Improved readme