### PR TITLE
Fix missing path argument for checkPerms during on empty file checking

### DIFF
--- a/SOURCES/rbbuild
+++ b/SOURCES/rbbuild
@@ -225,7 +225,7 @@ prepDefFile() {
     fetchRemoteDefFile "$1"
   else
     if checkPerms "FR" "$1" ; then
-      if checkPerms "S" ; then
+      if checkPerms "S" "$1" ; then
         def_file=$(getAbsPath "$1")
       else
         show "Error! Definition file is empty.\n" $RED


### PR DESCRIPTION
Hey, @andyone.

I found that `checkPerms` function is called with no path argument, so could cause error during on build new version of Ruby. I have been made quick fix of this typo.