### PR TITLE
Add Ruby 2.4.2 to the repository

### DIFF
--- a/SOURCES/defs/2.4.2-p0
+++ b/SOURCES/defs/2.4.2-p0
@@ -1,0 +1,17 @@
+# RBBuild Def File
+# UPDATED 06/Oct/2017 11:33:07 by Gleb Goncharov <g.goncharov@fun-box.ru>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+CONFOPTS(openssl-1.1.0d): gcc --openssldir={prefix}/openssl/ssl zlib-dynamic shared -fPIC
+MAKEOPTS(openssl-1.1.0d): -j 1
+PREFIX(openssl-1.1.0d): {prefix}/openssl
+
+CONFOPTS(ruby-2.4.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.1.0d" "https://www.openssl.org/source/openssl-1.1.0d.tar.gz" "f423e9253ad8a8617fc9fb3562788a9fa066d46f" openssl
+  package: "ruby-2.4.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz" "b096124469e31e4fc3d00d2b61b11d36992e6bbd"


### PR DESCRIPTION
Hello, @andyone.

I have tried to write the first manifest based on defs format for Ruby 2.4.2. Unfortunately, I did not fill the mirror section with a properly SHA1 string of 7z archive due to none access to EK mirror.

Thank you.