### PR TITLE
Add Ruby 2.5.1-p0 def

### DIFF
--- a/SOURCES/defs/2.5.1-p0
+++ b/SOURCES/defs/2.5.1-p0
@@ -1,0 +1,23 @@
+# RBBuild Def File
+# UPDATED 29/Mar/2018 14:40:19 by Gleb Goncharov <g.goncharov@fun-box.ru>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+deps(bin): ruby
+
+CONFOPTS(openssl-1.1.0g): gcc --openssldir={prefix}/openssl/ssl zlib-dynamic shared -fPIC
+MAKEOPTS(openssl-1.1.0g): -j 1
+PREFIX(openssl-1.1.0g): {prefix}/openssl
+
+CONFOPTS(ruby-2.5.1-p0): --with-openssl-dir={prefix}/openssl --with-baseruby={ruby_bin} --disable-install-doc
+
+[default]
+  package: "openssl-1.1.0g" "https://www.openssl.org/source/openssl-1.1.0h.tar.gz" "0fc39f6aa91b6e7f4d05018f7c5e991e1d2491fd" openssl
+  package: "ruby-2.5.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.gz" "93fafd57a724974b951957c522cdc4478a6bdc2e"
+
+[essentialkaos]
+  package: "openssl-1.1.0g" "https://ruby.kaos.st/openssl-1.1.0h.7z" "5e96a957be9f2a448dfd6a1bb2d07e1b6e1b8576" openssl
+  package: "ruby-2.5.1-p0" "https://ruby.kaos.st/ruby-2.5.1.7z" "7caba191bd65776bbd91c1eebdd19bd98982c675"

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -27,10 +27,10 @@
 
 ################################################################################
 
-Summary:         Def files for rbbuild utility 
+Summary:         Def files for rbbuild utility
 Name:            rbbuild-defs
-Version:         1.8.0
-Release:         1%{?dist}
+Version:         1.8.1
+Release:         0%{?dist}
 License:         EKOL
 Vendor:          ESSENTIALKAOS
 Group:           Development/Tools
@@ -39,9 +39,10 @@ URL:             https://github.com/essentialkaos/rbbuild
 BuildArch:       noarch
 BuildRoot:       %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+# perfecto:absolve 2
 Source0:         %{name}-%{version}.tar.bz2
 
-Requires:        rbbuild
+Requires:        rbbuild bc
 
 ################################################################################
 
@@ -75,6 +76,10 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Mar 29 2018 Gleb Goncharov <g.goncharov@fun-box.ru> - 1.8.1-0
+- Added 2.5.1-p0
+- Added bc to dependency list
+
 * Fri Feb 02 2018 Anton Novojilov <andy@essentialkaos.com> - 1.8.0-1
 - Migrated from kaos.io to kaos.st
 
@@ -389,7 +394,7 @@ rm -rf %{buildroot}
 * Tue Dec 10 2013 Anton Novojilov <andy@essentialkaos.com> - 1.1.2-0
 - Added 1.9.3-p484 1.9.3-p484-railsexpress
 - Added 2.0.0-p353 2.0.0-p353-railsexpress
-- Added rubinius-2.0.0 rubinius-2.1.0 rubinius-2.1.1 
+- Added rubinius-2.0.0 rubinius-2.1.0 rubinius-2.1.1
 - Added rubinius-2.2.0 rubinius-2.2.1
 - Removed rubinius-1.2.4
 


### PR DESCRIPTION
### What did you implement:

RBBuild definition for Ruby 2.5.1-p0.

### How did you implement it:

Ruby 2.5.1-p0 has been released two days ago, so I wrote RBBuild definition file to be able to build package for RBInstall repository.

### How can we verify it:

```
# Install dependencies
[sudo] yum -y install bison libffi-devel make ncurses-devel readline-devel tk-devel ruby

# Build package from RBBuild definition
rbbuild 2.5.1-p0 -p /tmp/2.5.1-p0 -m default
```

### TODO's:

- [ ] Repack `tar.gz` archives to `7z`.
- [ ] Calculate and verify SHA1 checksum.
- [ ] Upload `7z` archives to `ruby.kaos.st`.

**Is this ready for review?:** Yes
**Is it a breaking change?:** No