### PR TITLE
Add Ruby 2.6.3 (+jemalloc)

### DIFF
--- a/SOURCES/defs/2.6.3-p0
+++ b/SOURCES/defs/2.6.3-p0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 16/Mar/2019 00:40:48 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 04/Jun/2019 13:30:48 by Gleb Goncharov <inbox@gongled.ru>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.6.3-p0
+++ b/SOURCES/defs/2.6.3-p0
@@ -1,0 +1,23 @@
+# RBBuild Def File
+# UPDATED 16/Mar/2019 00:40:48 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+deps(bin): ruby
+
+CONFOPTS(openssl-1.1.1a): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1a): -j 1
+PREFIX(openssl-1.1.1a): {prefix}/openssl
+
+CONFOPTS(ruby-2.6.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.1.1a" "https://www.openssl.org/source/openssl-1.1.1a.tar.gz" "8fae27b4f34445a5500c9dc50ae66b4d6472ce29" openssl
+  package: "ruby-2.6.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.gz" "2347ed6ca5490a104ebd5684d2b9b5eefa6cd33c"
+
+[essentialkaos]
+  package: "openssl-1.1.1a" "https://ruby.kaos.st/openssl-1.1.1a.7z" "e1a2e02390bffccd263249a17ab347d9a9c49d8e" openssl
+  package: "ruby-2.6.3-p0" "https://ruby.kaos.st/ruby-2.6.3.7z" "c76b54231329fb63e0a9efd08b37b68f353824e2"

--- a/SOURCES/defs/2.6.3-p0-jemalloc
+++ b/SOURCES/defs/2.6.3-p0-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 16/Mar/2019 00:40:48 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 04/Jun/2019 13:30:48 by Gleb Goncharov <inbox@gongled.ru>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel

--- a/SOURCES/defs/2.6.3-p0-jemalloc
+++ b/SOURCES/defs/2.6.3-p0-jemalloc
@@ -1,0 +1,21 @@
+# RBBuild Def File
+# UPDATED 16/Mar/2019 00:40:48 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
+
+deps(bin): ruby
+
+CONFOPTS(openssl-1.1.1a): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1a): -j 1
+PREFIX(openssl-1.1.1a): {prefix}/openssl
+
+CONFOPTS(ruby-2.6.3-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.1.1a" "https://www.openssl.org/source/openssl-1.1.1a.tar.gz" "8fae27b4f34445a5500c9dc50ae66b4d6472ce29" openssl
+  package: "ruby-2.6.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.gz" "2347ed6ca5490a104ebd5684d2b9b5eefa6cd33c"
+
+[essentialkaos]
+  package: "openssl-1.1.1a" "https://ruby.kaos.st/openssl-1.1.1a.7z" "e1a2e02390bffccd263249a17ab347d9a9c49d8e" openssl
+  package: "ruby-2.6.3-p0" "https://ruby.kaos.st/ruby-2.6.3.7z" "c76b54231329fb63e0a9efd08b37b68f353824e2"


### PR DESCRIPTION
### What did you implement:

I added definitions of Ruby 2.6.3 with jemalloc support. Please, verify these specs, pack dependencies and set up a proper checksum for 7z archives hosted on your repository. I ask you to publish prebuilt Ruby versions for RBInstall too.

**Is this ready for review?:** Yes
**Is it a breaking change?:** No
