### PR TITLE
Add Ruby 2.7.2 (+jemalloc)

### DIFF
--- a/SOURCES/defs/2.7.2
+++ b/SOURCES/defs/2.7.2
@@ -1,0 +1,19 @@
+# RBBuild Def File
+# UPDATED 29/Jan/2021 10:30:04 by Gleb Goncharov <g.goncharov@fun-box.ru>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+deps(bin): ruby
+
+CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1f): -j 1
+PREFIX(openssl-1.1.1f): {prefix}/openssl
+
+CONFOPTS(ruby-2.7.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "ruby-2.7.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz" "cb9731a17487e0ad84037490a6baf8bfa31a09e8"

--- a/SOURCES/defs/2.7.2-jemalloc
+++ b/SOURCES/defs/2.7.2-jemalloc
@@ -1,0 +1,17 @@
+# RBBuild Def File
+# UPDATED 29/Jan/2021 10:30:04 by Gleb Goncharov <g.goncharov@fun-box.ru>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
+
+deps(bin): ruby
+
+CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1f): -j 1
+PREFIX(openssl-1.1.1f): {prefix}/openssl
+
+CONFOPTS(ruby-2.7.2-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "ruby-2.7.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz" "cb9731a17487e0ad84037490a6baf8bfa31a09e8"


### PR DESCRIPTION
### What did you implement:

I have added two more definitions for Ruby 2.7.2 with/without `jemalloc` for Ruby 2.7.x branch. Unfortunately, there is no way to contribute to railsexpress patches and calculate the SHA1 hash for repacked 7z archive, so I decided not to specify `[essentialkaos]` section in files at all. However, I have already got SHA1 from the source tarball.

### How did you implement it:

Not applicable.

### How can we verify it:

Not applicable.

### TODO's:

- [x] Write tests (not applicable)
- [x] Write documentation (not applicable)
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Provide verification config / commands (not applicable)
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**Is this ready for review?:** Yes
**Is it a breaking change?:** No
