### PR TITLE
Defs update

### DIFF
--- a/SOURCES/defs/1.9.2-p180
+++ b/SOURCES/defs/1.9.2-p180
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:32:06 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,20 +10,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p180): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.2-p180" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz" "6a482bc07239b37bcadf68dda63c65d20dc19ebe"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.2-p180" "https://ruby.kaos.st/ruby-1.9.2-p180.7z" "6977b200893b7b34e8f82ccc2843b9c056419d2b"
   package: "rubygems-2.4.7" "https://ruby.kaos.st/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p180-railsexpress
+++ b/SOURCES/defs/1.9.2-p180-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:32:06 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,22 +10,22 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p180): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.2-p180.7z" "04e00f7a910eb1a4c8b38ddf69a908e8efffad16"
   package: "ruby-1.9.2-p180" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz" "6a482bc07239b37bcadf68dda63c65d20dc19ebe"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.2-p180.7z" "04e00f7a910eb1a4c8b38ddf69a908e8efffad16"
   package: "ruby-1.9.2-p180" "https://ruby.kaos.st/ruby-1.9.2-p180.7z" "6977b200893b7b34e8f82ccc2843b9c056419d2b"
   package: "rubygems-2.4.7" "https://ruby.kaos.st/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p290
+++ b/SOURCES/defs/1.9.2-p290
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:32:06 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,20 +10,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p290): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.2-p290" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz" "16fc9cf2223fc34821bc491fb3827f11cc5627ec"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.2-p290" "https://ruby.kaos.st/ruby-1.9.2-p290.7z" "722bb29d96d20b27951f671728c131d071d1d584"
   package: "rubygems-2.4.7" "https://ruby.kaos.st/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p290-railsexpress
+++ b/SOURCES/defs/1.9.2-p290-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:32:06 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,22 +10,22 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p290): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.2-p290.7z" "23351e4ab75829c8c7269325d0d5163b13dc440d"
   package: "ruby-1.9.2-p290" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz" "16fc9cf2223fc34821bc491fb3827f11cc5627ec"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.2-p290.7z" "23351e4ab75829c8c7269325d0d5163b13dc440d"
   package: "ruby-1.9.2-p290" "https://ruby.kaos.st/ruby-1.9.2-p290.7z" "722bb29d96d20b27951f671728c131d071d1d584"
   package: "rubygems-2.4.7" "https://ruby.kaos.st/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p318
+++ b/SOURCES/defs/1.9.2-p318
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:32:06 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,20 +10,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p318): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.2-p318" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.gz" "8402e3726bcf62b422b1e9dd8a425b8707dc4042"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.2-p318" "https://ruby.kaos.st/ruby-1.9.2-p318.7z" "3b2839024c6680ae6cae74ef10a61484707155f7"
   package: "rubygems-2.4.7" "https://ruby.kaos.st/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p318-railsexpress
+++ b/SOURCES/defs/1.9.2-p318-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:32:06 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,22 +10,22 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p318): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.2-p318.7z" "8747f70f70ede660181e76cc87d75b949e6134c4"
   package: "ruby-1.9.2-p318" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.gz" "8402e3726bcf62b422b1e9dd8a425b8707dc4042"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.2-p318.7z" "8747f70f70ede660181e76cc87d75b949e6134c4"
   package: "ruby-1.9.2-p318" "https://ruby.kaos.st/ruby-1.9.2-p318.7z" "3b2839024c6680ae6cae74ef10a61484707155f7"
   package: "rubygems-2.4.7" "https://ruby.kaos.st/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p320
+++ b/SOURCES/defs/1.9.2-p320
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:32:06 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,20 +10,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p320): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.2-p320" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.gz" "ead282bf780eb671a627e5e071f96c2fa4c64c1a"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.2-p320" "https://ruby.kaos.st/ruby-1.9.2-p320.7z" "ff61212867801e4bac0acd59df398a74f7c5719f"
   package: "rubygems-2.4.7" "https://ruby.kaos.st/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p320-railsexpress
+++ b/SOURCES/defs/1.9.2-p320-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:32:06 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,22 +10,22 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p320): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.2-p320.7z" "8747f70f70ede660181e76cc87d75b949e6134c4"
   package: "ruby-1.9.2-p320" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.gz" "ead282bf780eb671a627e5e071f96c2fa4c64c1a"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.2-p320.7z" "8747f70f70ede660181e76cc87d75b949e6134c4"
   package: "ruby-1.9.2-p320" "https://ruby.kaos.st/ruby-1.9.2-p320.7z" "ff61212867801e4bac0acd59df398a74f7c5719f"
   package: "rubygems-2.4.7" "https://ruby.kaos.st/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.2-p330
+++ b/SOURCES/defs/1.9.2-p330
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:32:06 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2012-06-01
 eol(security): 2013-06-01
@@ -10,20 +10,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.2-p330): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.2-p330" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz" "d25dca1adf186a1be7dcf12a48ea4c7abadfcf12"
   package: "rubygems-2.4.7" "http://production.cf.rubygems.org/rubygems/rubygems-2.4.7.tgz" "5cb12bd69ad1c80a01e98bcd012a37ac10b710d2" ruby
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.2-p330" "https://ruby.kaos.st/ruby-1.9.2-p330.7z" "6f832a99a77525ebec75ba820440215faa0d8693"
   package: "rubygems-2.4.7" "https://ruby.kaos.st/rubygems-2.4.7.7z" "93cf521e4ff9d8f6c3d425d0b52cfc5fa038b354" ruby

--- a/SOURCES/defs/1.9.3-p0
+++ b/SOURCES/defs/1.9.3-p0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p0): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.gz" "f7cef9ad2808a1f522427c9116416973b9fcaf1a"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p0" "https://ruby.kaos.st/ruby-1.9.3-p0.7z" "276f536523111e7986d0e86dfba636b7063e2400"

--- a/SOURCES/defs/1.9.3-p105
+++ b/SOURCES/defs/1.9.3-p105
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p105): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
   package: "ruby-1.9.3-p105" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p105.tar.gz" "9943afce862e28b7952af0cd4091b3e8d3358b1e"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p105" "https://ruby.kaos.st/ruby-1.9.3-p105.7z" "234c6eb697a766851deb487da07d929c2bf951d9"

--- a/SOURCES/defs/1.9.3-p125
+++ b/SOURCES/defs/1.9.3-p125
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev
 deps(deb): autoconf libc6-dev libncurses5-dev bison
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p125): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p125" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.gz" "3ea11df6bc4e7537cf97f7b134db24c55dfe013d"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p125" "https://ruby.kaos.st/ruby-1.9.3-p125.7z" "e48f2591a6fa38b2283440e8f95b87bf4535bb29"

--- a/SOURCES/defs/1.9.3-p125-railsexpress
+++ b/SOURCES/defs/1.9.3-p125-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p125): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p125.7z" "d13bc65da0f869573f567f745cc6ba8683b654c5"
   package: "ruby-1.9.3-p125" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.gz" "3ea11df6bc4e7537cf97f7b134db24c55dfe013d"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p125.7z" "d13bc65da0f869573f567f745cc6ba8683b654c5"
   package: "ruby-1.9.3-p125" "https://ruby.kaos.st/ruby-1.9.3-p125.7z" "e48f2591a6fa38b2283440e8f95b87bf4535bb29"

--- a/SOURCES/defs/1.9.3-p194
+++ b/SOURCES/defs/1.9.3-p194
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p194): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p194" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.gz" "" "31cf6bd981e4c929e5dc3bbdb341833eab1bd9f2"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p194" "https://ruby.kaos.st/ruby-1.9.3-p194.7z" "cdea4ee081df868b376f646b6804e69cb73da707"

--- a/SOURCES/defs/1.9.3-p194-railsexpress
+++ b/SOURCES/defs/1.9.3-p194-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p194): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p194.7z" "a9035dc9253e5368f100815504640409bb356d5b"
   package: "ruby-1.9.3-p194" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.gz" "31cf6bd981e4c929e5dc3bbdb341833eab1bd9f2"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p194.7z" "a9035dc9253e5368f100815504640409bb356d5b"
   package: "ruby-1.9.3-p194" "https://ruby.kaos.st/ruby-1.9.3-p194.7z" "cdea4ee081df868b376f646b6804e69cb73da707"

--- a/SOURCES/defs/1.9.3-p286
+++ b/SOURCES/defs/1.9.3-p286
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p286): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p286" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.gz" "baac543eafc1d95513489edc051ebbbcbe849122"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p286" "https://ruby.kaos.st/ruby-1.9.3-p286.7z" "f9a72ff3e5112edb60e826a1f039e5926bba204f"

--- a/SOURCES/defs/1.9.3-p286-railsexpress
+++ b/SOURCES/defs/1.9.3-p286-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p286): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p286.7z" "8d3f02477e4df906eac52ce839869335b41c26e8"
   package: "ruby-1.9.3-p286" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.gz" "baac543eafc1d95513489edc051ebbbcbe849122"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p286.7z" "8d3f02477e4df906eac52ce839869335b41c26e8"
   package: "ruby-1.9.3-p286" "https://ruby.kaos.st/ruby-1.9.3-p286.7z" "f9a72ff3e5112edb60e826a1f039e5926bba204f"

--- a/SOURCES/defs/1.9.3-p327
+++ b/SOURCES/defs/1.9.3-p327
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p327): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p327" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.gz" "a4075e5126278b5cba982d8c832dc03114e7a02a"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p327" "https://ruby.kaos.st/ruby-1.9.3-p327.7z" "3aa165d85b978fd66a0613282b95583c93551541"

--- a/SOURCES/defs/1.9.3-p327-railsexpress
+++ b/SOURCES/defs/1.9.3-p327-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p327): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p327.7z" "1ede9f98eb23aa39a1f2d51f02eb9234b5f24929"
   package: "ruby-1.9.3-p327" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.gz" "a4075e5126278b5cba982d8c832dc03114e7a02a"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p327.7z" "1ede9f98eb23aa39a1f2d51f02eb9234b5f24929"
   package: "ruby-1.9.3-p327" "https://ruby.kaos.st/ruby-1.9.3-p327.7z" "3aa165d85b978fd66a0613282b95583c93551541"

--- a/SOURCES/defs/1.9.3-p362
+++ b/SOURCES/defs/1.9.3-p362
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p362): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p362" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p362.tar.gz" "bd9866115b484eb92bf7283834af63a92191e250"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p362" "https://ruby.kaos.st/ruby-1.9.3-p362.7z" "981ead05defde6d9a5352cff5982a91fd3b84930"

--- a/SOURCES/defs/1.9.3-p362-railsexpress
+++ b/SOURCES/defs/1.9.3-p362-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p362): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p362.7z" "c44215128a84e35b4963942010312ccaaba04537"
   package: "ruby-1.9.3-p362" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p362.tar.gz" "bd9866115b484eb92bf7283834af63a92191e250"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p362.7z" "c44215128a84e35b4963942010312ccaaba04537"
   package: "ruby-1.9.3-p362" "https://ruby.kaos.st/ruby-1.9.3-p362.7z" "981ead05defde6d9a5352cff5982a91fd3b84930"

--- a/SOURCES/defs/1.9.3-p374
+++ b/SOURCES/defs/1.9.3-p374
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p374): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p374" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p374.tar.gz" "62ec444899de428461e8476c4bca62469b331333"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p374" "https://ruby.kaos.st/ruby-1.9.3-p374.7z" "30e005b739ac5ce7a93a5f6e53fae37d73d2bfb8"

--- a/SOURCES/defs/1.9.3-p374-railsexpress
+++ b/SOURCES/defs/1.9.3-p374-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p374): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p374.7z" "2e64c1ccfdfc2f0a6a8527cec7bb41eafcc5c59c"
   package: "ruby-1.9.3-p374" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p374.tar.gz" "62ec444899de428461e8476c4bca62469b331333"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p374.7z" "2e64c1ccfdfc2f0a6a8527cec7bb41eafcc5c59c"
   package: "ruby-1.9.3-p374" "https://ruby.kaos.st/ruby-1.9.3-p374.7z" "30e005b739ac5ce7a93a5f6e53fae37d73d2bfb8"

--- a/SOURCES/defs/1.9.3-p385
+++ b/SOURCES/defs/1.9.3-p385
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p385): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p385" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p385.tar.gz" "5f7e7e64ca5aedeb9720f9cd056bfe81ab029a94"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p385" "https://ruby.kaos.st/ruby-1.9.3-p385.7z" "8a242a92aadf67e4cf804d399020f2819ccc0ac1"

--- a/SOURCES/defs/1.9.3-p385-railsexpress
+++ b/SOURCES/defs/1.9.3-p385-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p385): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p385.7z" "704cdb3fcb30242e83868f0ee888630ef5617ee3"
   package: "ruby-1.9.3-p385" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p385.tar.gz" "5f7e7e64ca5aedeb9720f9cd056bfe81ab029a94"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p385.7z" "704cdb3fcb30242e83868f0ee888630ef5617ee3"
   package: "ruby-1.9.3-p385" "https://ruby.kaos.st/ruby-1.9.3-p385.7z" "8a242a92aadf67e4cf804d399020f2819ccc0ac1"

--- a/SOURCES/defs/1.9.3-p392
+++ b/SOURCES/defs/1.9.3-p392
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p392): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p392" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.gz" "ec75fcbd3b6b46ce6ec997ee4c86145b4abd5748"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p392" "https://ruby.kaos.st/ruby-1.9.3-p392.7z" "0917ad0532b0e873e17aab8c905326656278cfc0"

--- a/SOURCES/defs/1.9.3-p392-railsexpress
+++ b/SOURCES/defs/1.9.3-p392-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:26:59 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p392): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p392.7z" "ce27664d95279ef185d60639594ee0a2c7037554"
   package: "ruby-1.9.3-p392" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.gz" "ec75fcbd3b6b46ce6ec997ee4c86145b4abd5748"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p392.7z" "ce27664d95279ef185d60639594ee0a2c7037554"
   package: "ruby-1.9.3-p392" "https://ruby.kaos.st/ruby-1.9.3-p392.7z" "0917ad0532b0e873e17aab8c905326656278cfc0"

--- a/SOURCES/defs/1.9.3-p426
+++ b/SOURCES/defs/1.9.3-p426
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:00 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p426): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p426" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p426.tar.gz" "00ba5d9736d5783fbca93ef367d8861d20f2f768"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p426" "https://ruby.kaos.st/ruby-1.9.3-p426.7z" "2a5c399e12e1016fe84bb9e7402975507c6615dd"

--- a/SOURCES/defs/1.9.3-p429
+++ b/SOURCES/defs/1.9.3-p429
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:00 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p429): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p429" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz" "a1c3a25eb0720cb5f339343ad9605448089ff7cd"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p429" "https://ruby.kaos.st/ruby-1.9.3-p429.7z" "568c786b0935db9897a957f76a2ed5f9d4779a92"

--- a/SOURCES/defs/1.9.3-p429-railsexpress
+++ b/SOURCES/defs/1.9.3-p429-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:00 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p429): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p429.7z" "a0b6c8fd15ae8c582e8d3377e14b15d13223099d"
   package: "ruby-1.9.3-p429" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz" "a1c3a25eb0720cb5f339343ad9605448089ff7cd"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p429.7z" "a0b6c8fd15ae8c582e8d3377e14b15d13223099d"
   package: "ruby-1.9.3-p429" "https://ruby.kaos.st/ruby-1.9.3-p429.7z" "568c786b0935db9897a957f76a2ed5f9d4779a92"

--- a/SOURCES/defs/1.9.3-p448
+++ b/SOURCES/defs/1.9.3-p448
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:00 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p448): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p448" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.gz" "c7f736e3bc1ca1e6619a9121837dd0840aad77ce"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p448" "https://ruby.kaos.st/ruby-1.9.3-p448.7z" "2f9535e18a2cdaf539ae77c54b8f0516990dbf39"

--- a/SOURCES/defs/1.9.3-p448-railsexpress
+++ b/SOURCES/defs/1.9.3-p448-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:00 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:43 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p448): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p448.7z" "8d934638a7d83fa0ab39874534660740cd5b720b"
   package: "ruby-1.9.3-p448" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.gz" "c7f736e3bc1ca1e6619a9121837dd0840aad77ce"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p448.7z" "8d934638a7d83fa0ab39874534660740cd5b720b"
   package: "ruby-1.9.3-p448" "https://ruby.kaos.st/ruby-1.9.3-p448.7z" "2f9535e18a2cdaf539ae77c54b8f0516990dbf39"

--- a/SOURCES/defs/1.9.3-p484
+++ b/SOURCES/defs/1.9.3-p484
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:00 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p484): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p484" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.gz" "6ae80f424968b5ce661ee9b2bee1c21adc9ee67c"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p484" "https://ruby.kaos.st/ruby-1.9.3-p484.7z" "5eb20aee834fbe1d55b2a3ec7e318a02ec32f753"

--- a/SOURCES/defs/1.9.3-p484-railsexpress
+++ b/SOURCES/defs/1.9.3-p484-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:00 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p484): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p484.7z" "2bbc52f43133201f35f55e569d9953d11dfc6466"
   package: "ruby-1.9.3-p484" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.gz" "6ae80f424968b5ce661ee9b2bee1c21adc9ee67c"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p484.7z" "2bbc52f43133201f35f55e569d9953d11dfc6466"
   package: "ruby-1.9.3-p484" "https://ruby.kaos.st/ruby-1.9.3-p484.7z" "5eb20aee834fbe1d55b2a3ec7e318a02ec32f753"

--- a/SOURCES/defs/1.9.3-p545
+++ b/SOURCES/defs/1.9.3-p545
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:00 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p545): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p545" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.gz" "03455364740914e8d2dfd6421f681b3fb68a4313"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p545" "https://ruby.kaos.st/ruby-1.9.3-p545.7z" "743bb154c45b107243e6198ec17c66cab138cf82"

--- a/SOURCES/defs/1.9.3-p545-railsexpress
+++ b/SOURCES/defs/1.9.3-p545-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:00 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p545): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p545.7z" "0dfaa0023c4625a6fbf906954d4fe1918ebc9ad6"
   package: "ruby-1.9.3-p545" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.gz" "03455364740914e8d2dfd6421f681b3fb68a4313"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p545.7z" "0dfaa0023c4625a6fbf906954d4fe1918ebc9ad6"
   package: "ruby-1.9.3-p545" "https://ruby.kaos.st/ruby-1.9.3-p545.7z" "743bb154c45b107243e6198ec17c66cab138cf82"

--- a/SOURCES/defs/1.9.3-p547
+++ b/SOURCES/defs/1.9.3-p547
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:00 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p547): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p547" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p547.tar.gz" "01a792f972f5787ce526a1aad62976c56c93174b"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p547" "https://ruby.kaos.st/ruby-1.9.3-p547.7z" "e9b58c3f7dd44ff057ce70fe7800663c5ea800a2"

--- a/SOURCES/defs/1.9.3-p547-railsexpress
+++ b/SOURCES/defs/1.9.3-p547-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:00 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p547): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p547.7z" "f1261d254a4ba44b830dc6d90e6133f9e89c362f"
   package: "ruby-1.9.3-p547" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p547.tar.gz" "01a792f972f5787ce526a1aad62976c56c93174b"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p547.7z" "f1261d254a4ba44b830dc6d90e6133f9e89c362f"
   package: "ruby-1.9.3-p547" "https://ruby.kaos.st/ruby-1.9.3-p547.7z" "e9b58c3f7dd44ff057ce70fe7800663c5ea800a2"

--- a/SOURCES/defs/1.9.3-p551
+++ b/SOURCES/defs/1.9.3-p551
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:00 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p551): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-1.9.3-p551" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz" "5cf6c9383444163a3f753b50c35e441988189258"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-1.9.3-p551" "https://ruby.kaos.st/ruby-1.9.3-p551.7z" "a1d04d176889210f428590fad15619a34064ffd6"

--- a/SOURCES/defs/1.9.3-p551-railsexpress
+++ b/SOURCES/defs/1.9.3-p551-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:00 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2014-02-23
 eol(security): 2015-02-23
@@ -9,20 +9,20 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-1.9.3-p551): --with-openssl-dir={prefix}/openssl --with-opt-dir={prefix} --disable-install-doc
 
 [default]
   package: "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" "f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d"
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p551.7z" "2e8c7109929837a9de4f77f2aeb110da5159ba15"
   package: "ruby-1.9.3-p551" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz" "5cf6c9383444163a3f753b50c35e441988189258"
 
 [essentialkaos]
   package: "yaml-0.1.6" "https://ruby.kaos.st/yaml-0.1.6.7z" "f223c0c924e9f7d598d83d3127e7aac362c2589f"
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/1.9.3-p551.7z" "2e8c7109929837a9de4f77f2aeb110da5159ba15"
   package: "ruby-1.9.3-p551" "https://ruby.kaos.st/ruby-1.9.3-p551.7z" "a1d04d176889210f428590fad15619a34064ffd6"

--- a/SOURCES/defs/2.0.0-p0
+++ b/SOURCES/defs/2.0.0-p0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.gz" "5349078b65fdeea85c7217d0ca98e718d3612df4"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.0.0-p0" "https://ruby.kaos.st/ruby-2.0.0-p0.7z" "141c4e9e70b026eea5397d86f91d32d02d8c6df4"

--- a/SOURCES/defs/2.0.0-p195
+++ b/SOURCES/defs/2.0.0-p195
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p195): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.0.0-p195" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.gz" "4935832c49d48e177dcf46d801faff29f11be811"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.0.0-p195" "https://ruby.kaos.st/ruby-2.0.0-p195.7z" "8b556d05857435852d61b58c531d3784e17caeef"

--- a/SOURCES/defs/2.0.0-p247
+++ b/SOURCES/defs/2.0.0-p247
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p247): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.0.0-p247" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz" "850b93afb5914ee3f38f0769e309abf0cedf084b"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.0.0-p247" "https://ruby.kaos.st/ruby-2.0.0-p247.7z" "677401e7c9e6a8be1384f6f4b18c82da96405cf6"

--- a/SOURCES/defs/2.0.0-p247-railsexpress
+++ b/SOURCES/defs/2.0.0-p247-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p247): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p247.7z" "73ea3dec1b0fb13a3a22ce7a745765b12739322f"
   package: "ruby-2.0.0-p247" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz" "850b93afb5914ee3f38f0769e309abf0cedf084b"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p247.7z" "73ea3dec1b0fb13a3a22ce7a745765b12739322f"
   package: "ruby-2.0.0-p247" "https://ruby.kaos.st/ruby-2.0.0-p247.7z" "677401e7c9e6a8be1384f6f4b18c82da96405cf6"

--- a/SOURCES/defs/2.0.0-p353
+++ b/SOURCES/defs/2.0.0-p353
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p353): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.0.0-p353" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.gz" "7f2c8b8f5682aabc1114f44d36d314c6c37c11b8"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.0.0-p353" "https://ruby.kaos.st/ruby-2.0.0-p353.7z" "d6b46d2e7e7d552eee143fa0d07a645dbd1d9773"

--- a/SOURCES/defs/2.0.0-p353-railsexpress
+++ b/SOURCES/defs/2.0.0-p353-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p353): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p353.7z" "3b2647a634975629735ecac491523ace636b1678"
   package: "ruby-2.0.0-p353" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.gz" "7f2c8b8f5682aabc1114f44d36d314c6c37c11b8"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p353.7z" "3b2647a634975629735ecac491523ace636b1678"
   package: "ruby-2.0.0-p353" "https://ruby.kaos.st/ruby-2.0.0-p353.7z" "d6b46d2e7e7d552eee143fa0d07a645dbd1d9773"

--- a/SOURCES/defs/2.0.0-p451
+++ b/SOURCES/defs/2.0.0-p451
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p451): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.0.0-p451" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.gz" "258adeba517c04f2c972736dece6c27ecea03432"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.0.0-p451" "https://ruby.kaos.st/ruby-2.0.0-p451.7z" "22d1eaadfac357fe5c71a55d5bfd579ece3fb22f"

--- a/SOURCES/defs/2.0.0-p451-railsexpress
+++ b/SOURCES/defs/2.0.0-p451-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p451): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p451.7z" "a2432dccb835ab6734dacd73431ca1963a1ebb5e"
   package: "ruby-2.0.0-p451" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.gz" "258adeba517c04f2c972736dece6c27ecea03432"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p451.7z" "a2432dccb835ab6734dacd73431ca1963a1ebb5e"
   package: "ruby-2.0.0-p451" "https://ruby.kaos.st/ruby-2.0.0-p451.7z" "22d1eaadfac357fe5c71a55d5bfd579ece3fb22f"

--- a/SOURCES/defs/2.0.0-p481
+++ b/SOURCES/defs/2.0.0-p481
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p481): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.0.0-p481" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.gz" "dded7b7349d59feb83d4f774b2ddec23eeab7978"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.0.0-p481" "https://ruby.kaos.st/ruby-2.0.0-p481.7z" "989d930f832cc54be5465e99631b3e204eed7a4b"

--- a/SOURCES/defs/2.0.0-p481-railsexpress
+++ b/SOURCES/defs/2.0.0-p481-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p481): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p481.7z" "3bfe65aac5980780f83dbcc89a6a5cc089ca2943"
   package: "ruby-2.0.0-p481" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.gz" "dded7b7349d59feb83d4f774b2ddec23eeab7978"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p481.7z" "3bfe65aac5980780f83dbcc89a6a5cc089ca2943"
   package: "ruby-2.0.0-p481" "https://ruby.kaos.st/ruby-2.0.0-p481.7z" "989d930f832cc54be5465e99631b3e204eed7a4b"

--- a/SOURCES/defs/2.0.0-p576
+++ b/SOURCES/defs/2.0.0-p576
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p576): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.0.0-p576" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.gz" "5bf54cbcc6c19729f85110d165eb90c702289662"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.0.0-p576" "https://ruby.kaos.st/ruby-2.0.0-p576.7z" "200df22bc8aee83b85d1fe3e825eb262cb0537df"

--- a/SOURCES/defs/2.0.0-p594
+++ b/SOURCES/defs/2.0.0-p594
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p594): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.0.0-p594" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.gz" "d448fb9dde621a645f931a25a3addc4458e69d36"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.0.0-p594" "https://ruby.kaos.st/ruby-2.0.0-p594.7z" "d2053e35819d0089990a67525bd8458da5a4f2f2"

--- a/SOURCES/defs/2.0.0-p594-railsexpress
+++ b/SOURCES/defs/2.0.0-p594-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p594): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p594.7z" "e69e1881c273722e40a69b395af9298230f1a276"
   package: "ruby-2.0.0-p594" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.gz" "d448fb9dde621a645f931a25a3addc4458e69d36"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p594.7z" "e69e1881c273722e40a69b395af9298230f1a276"
   package: "ruby-2.0.0-p594" "https://ruby.kaos.st/ruby-2.0.0-p594.7z" "d2053e35819d0089990a67525bd8458da5a4f2f2"

--- a/SOURCES/defs/2.0.0-p598
+++ b/SOURCES/defs/2.0.0-p598
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p598): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.0.0-p598" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.gz" "2ef5e28b7ff0583f2f51ba498d317a86c71a5aa0"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.0.0-p598" "https://ruby.kaos.st/ruby-2.0.0-p598.7z" "4a553fb61c416433c74f53b2a2dbf2e6e239fa69"

--- a/SOURCES/defs/2.0.0-p598-railsexpress
+++ b/SOURCES/defs/2.0.0-p598-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p598): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p598.7z" "e69e1881c273722e40a69b395af9298230f1a276"
   package: "ruby-2.0.0-p598" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.gz" "2ef5e28b7ff0583f2f51ba498d317a86c71a5aa0"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p598.7z" "e69e1881c273722e40a69b395af9298230f1a276"
   package: "ruby-2.0.0-p598" "https://ruby.kaos.st/ruby-2.0.0-p598.7z" "4a553fb61c416433c74f53b2a2dbf2e6e239fa69"

--- a/SOURCES/defs/2.0.0-p643
+++ b/SOURCES/defs/2.0.0-p643
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p643): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.0.0-p643" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p643.tar.gz" "544840583939175886a0885bce1cf07f0b9550b7"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.0.0-p643" "https://ruby.kaos.st/ruby-2.0.0-p643.7z" "f5f56cda11804a76a4a7f1fcd287f9543614e45e"

--- a/SOURCES/defs/2.0.0-p645
+++ b/SOURCES/defs/2.0.0-p645
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p645): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.0.0-p645" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.gz" "4f922cda8d8f745f7b80cef8f79a0b51c252bbf5"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.0.0-p645" "https://ruby.kaos.st/ruby-2.0.0-p645.7z" "43244bee1ed90f0d5e2da8e285394de0a6db53cd"

--- a/SOURCES/defs/2.0.0-p645-railsexpress
+++ b/SOURCES/defs/2.0.0-p645-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p645): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p645.7z" "e299364ea51aa2bcbabed03a6a3079dbea68cf1d"
   package: "ruby-2.0.0-p645" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.gz" "4f922cda8d8f745f7b80cef8f79a0b51c252bbf5"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p645.7z" "e299364ea51aa2bcbabed03a6a3079dbea68cf1d"
   package: "ruby-2.0.0-p645" "https://ruby.kaos.st/ruby-2.0.0-p645.7z" "43244bee1ed90f0d5e2da8e285394de0a6db53cd"

--- a/SOURCES/defs/2.0.0-p647
+++ b/SOURCES/defs/2.0.0-p647
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p647): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.0.0-p647" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.gz" "1d5f2748104cb1011d2888d5ca6ecdb3bee1115a"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.0.0-p647" "https://ruby.kaos.st/ruby-2.0.0-p647.7z" "b3ea53cb9b7c6d84ed0bb3a0fc7163edcf9cad40"

--- a/SOURCES/defs/2.0.0-p647-railsexpress
+++ b/SOURCES/defs/2.0.0-p647-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p647): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p647.7z" "7690490148f179ae39d7ca2f424b60b8dd83901f"
   package: "ruby-2.0.0-p647" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.gz" "1d5f2748104cb1011d2888d5ca6ecdb3bee1115a"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p647.7z" "7690490148f179ae39d7ca2f424b60b8dd83901f"
   package: "ruby-2.0.0-p647" "https://ruby.kaos.st/ruby-2.0.0-p647.7z" "b3ea53cb9b7c6d84ed0bb3a0fc7163edcf9cad40"

--- a/SOURCES/defs/2.0.0-p648
+++ b/SOURCES/defs/2.0.0-p648
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p648): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.0.0-p648" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.gz" "2323df55f5e941c45be13500df9daf216098f884"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.0.0-p648" "https://ruby.kaos.st/ruby-2.0.0-p648.7z" "5acaee063f5edbf6a72b196c5d0ba3695225217a"

--- a/SOURCES/defs/2.0.0-p648-railsexpress
+++ b/SOURCES/defs/2.0.0-p648-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-02-24
 eol(security): 2016-02-24
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.0.0-p648): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p648.7z" "7690490148f179ae39d7ca2f424b60b8dd83901f"
   package: "ruby-2.0.0-p648" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.gz" "2323df55f5e941c45be13500df9daf216098f884"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.0.0-p648.7z" "7690490148f179ae39d7ca2f424b60b8dd83901f"
   package: "ruby-2.0.0-p648" "https://ruby.kaos.st/ruby-2.0.0-p648.7z" "5acaee063f5edbf6a72b196c5d0ba3695225217a"

--- a/SOURCES/defs/2.1.0
+++ b/SOURCES/defs/2.1.0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.1.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz" "99114e71c7765b5bdc0414c189a338f6f21fb51d"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.1.0-p0" "https://ruby.kaos.st/ruby-2.1.0.7z" "ca121697fc6b17752bff72f6257f58933531556e"

--- a/SOURCES/defs/2.1.0-railsexpress
+++ b/SOURCES/defs/2.1.0-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.0-p0.7z" "ee31b19ecc83726a0d7215c6c154a559bf21c263"
   package: "ruby-2.1.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz" "99114e71c7765b5bdc0414c189a338f6f21fb51d"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.0-p0.7z" "ee31b19ecc83726a0d7215c6c154a559bf21c263"
   package: "ruby-2.1.0-p0" "https://ruby.kaos.st/ruby-2.1.0.7z" "ca121697fc6b17752bff72f6257f58933531556e"

--- a/SOURCES/defs/2.1.1
+++ b/SOURCES/defs/2.1.1
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.1.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.gz" "27cbc8ae98863b4607ede8085beca2a20f4c03fd"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.1.1-p0" "https://ruby.kaos.st/ruby-2.1.1.7z" "0d6701f1eff9062a318fd1b1931714706fb5af49"

--- a/SOURCES/defs/2.1.1-railsexpress
+++ b/SOURCES/defs/2.1.1-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.1-p0.7z" "6026e9cbd943b105da7f27488d79f4228c35e70c"
   package: "ruby-2.1.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.gz" "27cbc8ae98863b4607ede8085beca2a20f4c03fd"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.1-p0.7z" "6026e9cbd943b105da7f27488d79f4228c35e70c"
   package: "ruby-2.1.1-p0" "https://ruby.kaos.st/ruby-2.1.1.7z" "0d6701f1eff9062a318fd1b1931714706fb5af49"

--- a/SOURCES/defs/2.1.10
+++ b/SOURCES/defs/2.1.10
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.10-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.1.10-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.gz" "2a5194b1fd42a3f1f23f1e0844ae78332a9efd5d"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.1.10-p0" "https://ruby.kaos.st/ruby-2.1.10.7z" "30bd437feae430b0f77f8f9e6890c4784b25ba2d"

--- a/SOURCES/defs/2.1.2
+++ b/SOURCES/defs/2.1.2
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.1.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz" "b818d56b4638f1949239038623b761517d4a5686"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.1.2-p0" "https://ruby.kaos.st/ruby-2.1.2.7z" "d8f68eba81cdd27329adea05ac26295ccc2c397c"

--- a/SOURCES/defs/2.1.2-railsexpress
+++ b/SOURCES/defs/2.1.2-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.2-p0.7z" "008a8c099dbb8e1542177ea4f2977994f3965f05"
   package: "ruby-2.1.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz" "b818d56b4638f1949239038623b761517d4a5686"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.2-p0.7z" "008a8c099dbb8e1542177ea4f2977994f3965f05"
   package: "ruby-2.1.2-p0" "https://ruby.kaos.st/ruby-2.1.2.7z" "d8f68eba81cdd27329adea05ac26295ccc2c397c"

--- a/SOURCES/defs/2.1.3
+++ b/SOURCES/defs/2.1.3
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.1.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.gz" "ca6e120e5a2ee7deb3a7493696b5bbc28bfc2236"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.1.3-p0" "https://ruby.kaos.st/ruby-2.1.3.7z" "47f147113f2fb4617cbe4acdf74f9cc1568b6f38"

--- a/SOURCES/defs/2.1.3-railsexpress
+++ b/SOURCES/defs/2.1.3-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.3-p0.7z" "d1cd6cca842b0a3bbeb1a46141f88495623e4cb6"
   package: "ruby-2.1.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.gz" "ca6e120e5a2ee7deb3a7493696b5bbc28bfc2236"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.3-p0.7z" "d1cd6cca842b0a3bbeb1a46141f88495623e4cb6"
   package: "ruby-2.1.3-p0" "https://ruby.kaos.st/ruby-2.1.3.7z" "47f147113f2fb4617cbe4acdf74f9cc1568b6f38"

--- a/SOURCES/defs/2.1.4
+++ b/SOURCES/defs/2.1.4
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.1.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.4.tar.gz" "29e9cfdd9e989b7621d7696ef3f970262a08dbc3"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.1.4-p0" "https://ruby.kaos.st/ruby-2.1.4.7z" "588326de562a3b88bcb0f9dc591cb1f34c90d083"

--- a/SOURCES/defs/2.1.4-railsexpress
+++ b/SOURCES/defs/2.1.4-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.4-p0.7z" "a14cae2eae942c57354f02b624e8e6ef316b1b48"
   package: "ruby-2.1.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.4.tar.gz" "29e9cfdd9e989b7621d7696ef3f970262a08dbc3"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.4-p0.7z" "a14cae2eae942c57354f02b624e8e6ef316b1b48"
   package: "ruby-2.1.4-p0" "https://ruby.kaos.st/ruby-2.1.4.7z" "588326de562a3b88bcb0f9dc591cb1f34c90d083"

--- a/SOURCES/defs/2.1.5
+++ b/SOURCES/defs/2.1.5
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.1.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz" "9c0a238bd7839a4b51871641945a3da90997b8c2"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.1.5-p0" "https://ruby.kaos.st/ruby-2.1.5.7z" "aa8a855475e5f2f9cd5a3772bec1e759703aac96"

--- a/SOURCES/defs/2.1.5-railsexpress
+++ b/SOURCES/defs/2.1.5-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.5-p0.7z" "e3a01a15bc063a101d1e028966f8f391beb6af02"
   package: "ruby-2.1.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz" "9c0a238bd7839a4b51871641945a3da90997b8c2"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.5-p0.7z" "e3a01a15bc063a101d1e028966f8f391beb6af02"
   package: "ruby-2.1.5-p0" "https://ruby.kaos.st/ruby-2.1.5.7z" "aa8a855475e5f2f9cd5a3772bec1e759703aac96"

--- a/SOURCES/defs/2.1.6
+++ b/SOURCES/defs/2.1.6
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.1.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz" "426289b6647ce35ad101091825b6e7e5fce207f3"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.1.6-p0" "https://ruby.kaos.st/ruby-2.1.6.7z" "134423f860de36e81b55cbc7801c3030bac0f904"

--- a/SOURCES/defs/2.1.6-railsexpress
+++ b/SOURCES/defs/2.1.6-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.6-p0.7z" "212b2bd522a97dc58195e98f90b10f92c284257e"
   package: "ruby-2.1.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz" "426289b6647ce35ad101091825b6e7e5fce207f3"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.6-p0.7z" "212b2bd522a97dc58195e98f90b10f92c284257e"
   package: "ruby-2.1.6-p0" "https://ruby.kaos.st/ruby-2.1.6.7z" "134423f860de36e81b55cbc7801c3030bac0f904"

--- a/SOURCES/defs/2.1.7
+++ b/SOURCES/defs/2.1.7
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.1.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.gz" "e2e195a4a58133e3ad33b955c829bb536fa3c075"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.1.7-p0" "https://ruby.kaos.st/ruby-2.1.7.7z" "3ea60dca17d47859a942402ca139bad537f1a6ef"

--- a/SOURCES/defs/2.1.7-railsexpress
+++ b/SOURCES/defs/2.1.7-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.7-p0.7z" "92fce7ffb6849878b01c4688678239446b4641a3"
   package: "ruby-2.1.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.gz" "e2e195a4a58133e3ad33b955c829bb536fa3c075"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.7-p0.7z" "92fce7ffb6849878b01c4688678239446b4641a3"
   package: "ruby-2.1.7-p0" "https://ruby.kaos.st/ruby-2.1.7.7z" "3ea60dca17d47859a942402ca139bad537f1a6ef"

--- a/SOURCES/defs/2.1.8
+++ b/SOURCES/defs/2.1.8
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.8-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.1.8-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.gz" "c7e50159357afd87b13dc5eaf4ac486a70011149"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.1.8-p0" "https://ruby.kaos.st/ruby-2.1.8.7z" "2e6b06e4c1daea107b9d81cbdd5320e0b2c51bce"

--- a/SOURCES/defs/2.1.8-railsexpress
+++ b/SOURCES/defs/2.1.8-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.8-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.8-p0.7z" "2c1c813c00e164b84535a0b598e06d86cf326bef"
   package: "ruby-2.1.8-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.gz" "c7e50159357afd87b13dc5eaf4ac486a70011149"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.1.8-p0.7z" "2c1c813c00e164b84535a0b598e06d86cf326bef"
   package: "ruby-2.1.8-p0" "https://ruby.kaos.st/ruby-2.1.8.7z" "2e6b06e4c1daea107b9d81cbdd5320e0b2c51bce"

--- a/SOURCES/defs/2.1.9
+++ b/SOURCES/defs/2.1.9
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2016-03-31
 eol(security): 2016-09-30
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.1.9-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.1.9-p0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.gz" "dd68afc652fe542f83a9a709a74f4da2662054bf"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.1.9-p0" "https://ruby.kaos.st/ruby-2.1.9.7z" "9eccf2beb2b3559165c70e16e6612b97da403e7f"

--- a/SOURCES/defs/2.2.0
+++ b/SOURCES/defs/2.2.0
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.0
+++ b/SOURCES/defs/2.2.0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.2.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz" "680302104b24f850fddfe93ee37396de01765b37"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.2.0-p0" "https://ruby.kaos.st/ruby-2.2.0.7z" "75474ae076a855709cc1a8f0bcc9710e93cb2ef4"

--- a/SOURCES/defs/2.2.0-railsexpress
+++ b/SOURCES/defs/2.2.0-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.0-p0.7z" "102778e65705e9177e7c41a0d4201dec14bc77a4"
   package: "ruby-2.2.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz" "680302104b24f850fddfe93ee37396de01765b37"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.0-p0.7z" "102778e65705e9177e7c41a0d4201dec14bc77a4"
   package: "ruby-2.2.0-p0" "https://ruby.kaos.st/ruby-2.2.0.7z" "75474ae076a855709cc1a8f0bcc9710e93cb2ef4"

--- a/SOURCES/defs/2.2.0-railsexpress
+++ b/SOURCES/defs/2.2.0-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git

--- a/SOURCES/defs/2.2.1
+++ b/SOURCES/defs/2.2.1
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.2.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.1.tar.gz" "12376b79163e02bc9bd1a39329d67c3d19ccace9"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.2.1-p0" "https://ruby.kaos.st/ruby-2.2.1.7z" "3d7cf03cc96fb2be7a6bd956808b1e74236eab61"

--- a/SOURCES/defs/2.2.1
+++ b/SOURCES/defs/2.2.1
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.1-railsexpress
+++ b/SOURCES/defs/2.2.1-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git

--- a/SOURCES/defs/2.2.1-railsexpress
+++ b/SOURCES/defs/2.2.1-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.1-p0.7z" "7bfc89bd79e8c054945955711357ba3eaadfae98"
   package: "ruby-2.2.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.1.tar.gz" "12376b79163e02bc9bd1a39329d67c3d19ccace9"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.1-p0.7z" "7bfc89bd79e8c054945955711357ba3eaadfae98"
   package: "ruby-2.2.1-p0" "https://ruby.kaos.st/ruby-2.2.1.7z" "3d7cf03cc96fb2be7a6bd956808b1e74236eab61"

--- a/SOURCES/defs/2.2.10
+++ b/SOURCES/defs/2.2.10
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.10
+++ b/SOURCES/defs/2.2.10
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.10-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.2.10-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.10.tar.gz" "b0207c861f3fa41cbe4909ecb89bd2fcac81fe7c"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.2.10-p0" "https://ruby.kaos.st/ruby-2.2.10.7z" "65fff0c267bbab85eeb001f8d0e95a717761a191"

--- a/SOURCES/defs/2.2.10-railsexpress
+++ b/SOURCES/defs/2.2.10-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.10-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.10-p0.7z" "7f109f38c33da16fbedbb37cbc645552ad26f459"
   package: "ruby-2.2.10-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.10.tar.gz" "b0207c861f3fa41cbe4909ecb89bd2fcac81fe7c"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.10-p0.7z" "7f109f38c33da16fbedbb37cbc645552ad26f459"
   package: "ruby-2.2.10-p0" "https://ruby.kaos.st/ruby-2.2.10.7z" "65fff0c267bbab85eeb001f8d0e95a717761a191"

--- a/SOURCES/defs/2.2.10-railsexpress
+++ b/SOURCES/defs/2.2.10-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.2
+++ b/SOURCES/defs/2.2.2
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.2.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.gz" "29c51a17639d921b1ae51cd80a9d7584f67d5e1c"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.2.2-p0" "https://ruby.kaos.st/ruby-2.2.2.7z" "4ece011cb4e4e93b00ad454c6f8fc8319f90c2df"

--- a/SOURCES/defs/2.2.2
+++ b/SOURCES/defs/2.2.2
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.2-railsexpress
+++ b/SOURCES/defs/2.2.2-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git

--- a/SOURCES/defs/2.2.2-railsexpress
+++ b/SOURCES/defs/2.2.2-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel git
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev git
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.2-p0.7z" "9bb48a333c549bdb71aa4f19b01615959a8bf8a8"
   package: "ruby-2.2.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.gz" "29c51a17639d921b1ae51cd80a9d7584f67d5e1c"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.2-p0.7z" "9bb48a333c549bdb71aa4f19b01615959a8bf8a8"
   package: "ruby-2.2.2-p0" "https://ruby.kaos.st/ruby-2.2.2.7z" "4ece011cb4e4e93b00ad454c6f8fc8319f90c2df"

--- a/SOURCES/defs/2.2.3
+++ b/SOURCES/defs/2.2.3
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.2.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz" "0d9e158534cb31e72740138b8f697b57b448e5c3"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.2.3-p0" "https://ruby.kaos.st/ruby-2.2.3.7z" "fa528e394f4b9989d7048b25f2527a449cf223ca"

--- a/SOURCES/defs/2.2.3
+++ b/SOURCES/defs/2.2.3
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.3-railsexpress
+++ b/SOURCES/defs/2.2.3-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.3-p0.7z" "5c07e5ecfbda876cf5dba4c5e17e85957f21eb42"
   package: "ruby-2.2.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz" "0d9e158534cb31e72740138b8f697b57b448e5c3"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.3-p0.7z" "5c07e5ecfbda876cf5dba4c5e17e85957f21eb42"
   package: "ruby-2.2.3-p0" "https://ruby.kaos.st/ruby-2.2.3.7z" "fa528e394f4b9989d7048b25f2527a449cf223ca"

--- a/SOURCES/defs/2.2.3-railsexpress
+++ b/SOURCES/defs/2.2.3-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.4
+++ b/SOURCES/defs/2.2.4
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.2.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.gz" "818e5e157f76d4912ba3a7c7b4fc5156105e83c3"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.2.4-p0" "https://ruby.kaos.st/ruby-2.2.4.7z" "85357355248efa80ca69bee26806039780a5a8a3"

--- a/SOURCES/defs/2.2.4
+++ b/SOURCES/defs/2.2.4
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.4-railsexpress
+++ b/SOURCES/defs/2.2.4-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.4-railsexpress
+++ b/SOURCES/defs/2.2.4-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.4-p0.7z" "3035ba413a8c9fd41408ea7a02f6722096721886"
   package: "ruby-2.2.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.gz" "818e5e157f76d4912ba3a7c7b4fc5156105e83c3"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.4-p0.7z" "3035ba413a8c9fd41408ea7a02f6722096721886"
   package: "ruby-2.2.4-p0" "https://ruby.kaos.st/ruby-2.2.4.7z" "85357355248efa80ca69bee26806039780a5a8a3"

--- a/SOURCES/defs/2.2.5
+++ b/SOURCES/defs/2.2.5
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.2.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz" "457707459827bd527347a5cee7b4dc509b486713"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.2.5-p0" "https://ruby.kaos.st/ruby-2.2.5.7z" "cc5bbac25a417eb0594f3bbe6cea92f252fc3c90"

--- a/SOURCES/defs/2.2.5
+++ b/SOURCES/defs/2.2.5
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.5-railsexpress
+++ b/SOURCES/defs/2.2.5-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.5-p0.7z" "0cd436aa96c04483a0938fba9b589ace5205a1bf"
   package: "ruby-2.2.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz" "457707459827bd527347a5cee7b4dc509b486713"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.5-p0.7z" "0cd436aa96c04483a0938fba9b589ace5205a1bf"
   package: "ruby-2.2.5-p0" "https://ruby.kaos.st/ruby-2.2.5.7z" "cc5bbac25a417eb0594f3bbe6cea92f252fc3c90"

--- a/SOURCES/defs/2.2.5-railsexpress
+++ b/SOURCES/defs/2.2.5-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.6
+++ b/SOURCES/defs/2.2.6
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.6
+++ b/SOURCES/defs/2.2.6
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.2.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.tar.gz" "a5aaf19694470e543c8216e3f1189e48b6dbb0da"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.2.6-p0" "https://ruby.kaos.st/ruby-2.2.6.7z" "91066bc647b2a3c82e1f50ff9571647c92728329"

--- a/SOURCES/defs/2.2.6-railsexpress
+++ b/SOURCES/defs/2.2.6-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.6-p0.7z" "8eb48b8926fd3ea404582153a8c79e0333ba2acf"
   package: "ruby-2.2.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.tar.gz" "a5aaf19694470e543c8216e3f1189e48b6dbb0da"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.6-p0.7z" "8eb48b8926fd3ea404582153a8c79e0333ba2acf"
   package: "ruby-2.2.6-p0" "https://ruby.kaos.st/ruby-2.2.6.7z" "91066bc647b2a3c82e1f50ff9571647c92728329"

--- a/SOURCES/defs/2.2.6-railsexpress
+++ b/SOURCES/defs/2.2.6-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.7
+++ b/SOURCES/defs/2.2.7
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.2.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.7.tar.gz" "dc819c4810b009f282f3b794f61f0db313f03b19"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.2.7-p0" "https://ruby.kaos.st/ruby-2.2.7.7z" "82d0d54a5d950cd28b48e60918cb685afc34e690"

--- a/SOURCES/defs/2.2.7
+++ b/SOURCES/defs/2.2.7
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.7-railsexpress
+++ b/SOURCES/defs/2.2.7-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.7-railsexpress
+++ b/SOURCES/defs/2.2.7-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.7-p0.7z" "1d5b84f6ca6f098307ae1eabef5505d6572494e8"
   package: "ruby-2.2.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.7.tar.gz" "dc819c4810b009f282f3b794f61f0db313f03b19"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.7-p0.7z" "1d5b84f6ca6f098307ae1eabef5505d6572494e8"
   package: "ruby-2.2.7-p0" "https://ruby.kaos.st/ruby-2.2.7.7z" "82d0d54a5d950cd28b48e60918cb685afc34e690"

--- a/SOURCES/defs/2.2.8
+++ b/SOURCES/defs/2.2.8
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.8-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.2.8-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.gz" "15a6fca1bfe0488b24a204708a287904028aa367"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.2.8-p0" "https://ruby.kaos.st/ruby-2.2.8.7z" "c93666379062d8e27df8d0c208dd8b4a2d1f9b93"

--- a/SOURCES/defs/2.2.8
+++ b/SOURCES/defs/2.2.8
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.8-railsexpress
+++ b/SOURCES/defs/2.2.8-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.8-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.8-p0.7z" "9c55816b3b5a426054195c179529ed6a10c2a3d1"
   package: "ruby-2.2.8-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.gz" "15a6fca1bfe0488b24a204708a287904028aa367"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.8-p0.7z" "9c55816b3b5a426054195c179529ed6a10c2a3d1"
   package: "ruby-2.2.8-p0" "https://ruby.kaos.st/ruby-2.2.8.7z" "c93666379062d8e27df8d0c208dd8b4a2d1f9b93"

--- a/SOURCES/defs/2.2.8-railsexpress
+++ b/SOURCES/defs/2.2.8-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.9
+++ b/SOURCES/defs/2.2.9
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.9-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.2.9-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.gz" "cbeb1b892ffcaca8728c1cb8d513e1b485bc5eba"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.2.9-p0" "https://ruby.kaos.st/ruby-2.2.9.7z" "f9880a4cbd4edf4b9fe36656cbcc9e50362d3526"

--- a/SOURCES/defs/2.2.9
+++ b/SOURCES/defs/2.2.9
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.2.9-railsexpress
+++ b/SOURCES/defs/2.2.9-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2p): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2p): -j 1
-PREFIX(openssl-1.0.2p): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.2.9-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2p" "https://www.openssl.org/source/openssl-1.0.2p.tar.gz" "f34b5322e92415755c7d58bf5d0d5cf37666382c" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.9-p0.7z" "1ce0482a5323c3d3b7e75a22bfaf4d56c851c06f"
   package: "ruby-2.2.9-p0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.gz" "cbeb1b892ffcaca8728c1cb8d513e1b485bc5eba"
 
 [essentialkaos]
-  package: "openssl-1.0.2p" "https://ruby.kaos.st/openssl-1.0.2p.7z" "05a943d15d98a266911c0c1565f1c8a4034f6904" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.2.9-p0.7z" "1ce0482a5323c3d3b7e75a22bfaf4d56c851c06f"
   package: "ruby-2.2.9-p0" "https://ruby.kaos.st/ruby-2.2.9.7z" "f9880a4cbd4edf4b9fe36656cbcc9e50362d3526"

--- a/SOURCES/defs/2.2.9-railsexpress
+++ b/SOURCES/defs/2.2.9-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2018-03-31
+eol(security): 2018-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.0
+++ b/SOURCES/defs/2.3.0
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.0
+++ b/SOURCES/defs/2.3.0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.gz" "2dfcf7f33bda4078efca30ae28cb89cd0e36ddc4"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.0-p0" "https://ruby.kaos.st/ruby-2.3.0.7z" "dbcf56456199f72aaf05f930753d257342eb9855"

--- a/SOURCES/defs/2.3.0-jemalloc
+++ b/SOURCES/defs/2.3.0-jemalloc
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel

--- a/SOURCES/defs/2.3.0-jemalloc
+++ b/SOURCES/defs/2.3.0-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.0-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.gz" "2dfcf7f33bda4078efca30ae28cb89cd0e36ddc4"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.0-p0" "https://ruby.kaos.st/ruby-2.3.0.7z" "dbcf56456199f72aaf05f930753d257342eb9855"

--- a/SOURCES/defs/2.3.0-railsexpress
+++ b/SOURCES/defs/2.3.0-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.0-railsexpress
+++ b/SOURCES/defs/2.3.0-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.0-p0.7z" "5b1bb4459c0a88bf7752f2ea190b9e937f67f79b"
   package: "ruby-2.3.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.gz" "2dfcf7f33bda4078efca30ae28cb89cd0e36ddc4"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.0-p0.7z" "5b1bb4459c0a88bf7752f2ea190b9e937f67f79b"
   package: "ruby-2.3.0-p0" "https://ruby.kaos.st/ruby-2.3.0.7z" "dbcf56456199f72aaf05f930753d257342eb9855"

--- a/SOURCES/defs/2.3.1
+++ b/SOURCES/defs/2.3.1
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz" "c39b4001f7acb4e334cb60a0f4df72d434bef711"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.1-p0" "https://ruby.kaos.st/ruby-2.3.1.7z" "5fb212c92c1e68099f7fa3d6eb8ced053ee4af5b"

--- a/SOURCES/defs/2.3.1
+++ b/SOURCES/defs/2.3.1
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.1-jemalloc
+++ b/SOURCES/defs/2.3.1-jemalloc
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel

--- a/SOURCES/defs/2.3.1-jemalloc
+++ b/SOURCES/defs/2.3.1-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.1-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz" "c39b4001f7acb4e334cb60a0f4df72d434bef711"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.1-p0" "https://ruby.kaos.st/ruby-2.3.1.7z" "5fb212c92c1e68099f7fa3d6eb8ced053ee4af5b"

--- a/SOURCES/defs/2.3.1-railsexpress
+++ b/SOURCES/defs/2.3.1-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.1-railsexpress
+++ b/SOURCES/defs/2.3.1-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.1-p0.7z" "e2399f4df9b67ca143594a8aa82962c0567abe56"
   package: "ruby-2.3.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz" "c39b4001f7acb4e334cb60a0f4df72d434bef711"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.1-p0.7z" "e2399f4df9b67ca143594a8aa82962c0567abe56"
   package: "ruby-2.3.1-p0" "https://ruby.kaos.st/ruby-2.3.1.7z" "5fb212c92c1e68099f7fa3d6eb8ced053ee4af5b"

--- a/SOURCES/defs/2.3.2
+++ b/SOURCES/defs/2.3.2
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.gz" "baef56b27941bfbfac6e2cd005b686d320c7f124"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.2-p0" "https://ruby.kaos.st/ruby-2.3.2.7z" "46875f506ce3cf79291a8d2da6353054b82d0831"

--- a/SOURCES/defs/2.3.2
+++ b/SOURCES/defs/2.3.2
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.2-jemalloc
+++ b/SOURCES/defs/2.3.2-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.2-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.gz" "baef56b27941bfbfac6e2cd005b686d320c7f124"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.2-p0" "https://ruby.kaos.st/ruby-2.3.2.7z" "46875f506ce3cf79291a8d2da6353054b82d0831"

--- a/SOURCES/defs/2.3.2-jemalloc
+++ b/SOURCES/defs/2.3.2-jemalloc
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel

--- a/SOURCES/defs/2.3.3
+++ b/SOURCES/defs/2.3.3
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.gz" "1014ee699071aa2ddd501907d18cbe15399c997d"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.3-p0" "https://ruby.kaos.st/ruby-2.3.3.7z" "c89d2fdf8422f4745f2760cb238063221d76e3bf"

--- a/SOURCES/defs/2.3.3
+++ b/SOURCES/defs/2.3.3
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.3-jemalloc
+++ b/SOURCES/defs/2.3.3-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.3-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.gz" "1014ee699071aa2ddd501907d18cbe15399c997d"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.3-p0" "https://ruby.kaos.st/ruby-2.3.3.7z" "c89d2fdf8422f4745f2760cb238063221d76e3bf"

--- a/SOURCES/defs/2.3.3-jemalloc
+++ b/SOURCES/defs/2.3.3-jemalloc
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel

--- a/SOURCES/defs/2.3.3-railsexpress
+++ b/SOURCES/defs/2.3.3-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.3-railsexpress
+++ b/SOURCES/defs/2.3.3-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.3-p0.7z" "4d037796fdd3958cc01851ad156a5ee199ff35ad"
   package: "ruby-2.3.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.gz" "1014ee699071aa2ddd501907d18cbe15399c997d"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.3-p0.7z" "4d037796fdd3958cc01851ad156a5ee199ff35ad"
   package: "ruby-2.3.3-p0" "https://ruby.kaos.st/ruby-2.3.3.7z" "c89d2fdf8422f4745f2760cb238063221d76e3bf"

--- a/SOURCES/defs/2.3.4
+++ b/SOURCES/defs/2.3.4
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.4
+++ b/SOURCES/defs/2.3.4
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.gz" "d064b9c69329ca2eb2956ad57b7192184178e35d"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.4-p0" "https://ruby.kaos.st/ruby-2.3.4.7z" "905d314446a2f80bfabd72a3ee080a79f378b743"

--- a/SOURCES/defs/2.3.4-jemalloc
+++ b/SOURCES/defs/2.3.4-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.4-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.gz" "d064b9c69329ca2eb2956ad57b7192184178e35d"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.4-p0" "https://ruby.kaos.st/ruby-2.3.4.7z" "905d314446a2f80bfabd72a3ee080a79f378b743"

--- a/SOURCES/defs/2.3.4-jemalloc
+++ b/SOURCES/defs/2.3.4-jemalloc
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel

--- a/SOURCES/defs/2.3.4-railsexpress
+++ b/SOURCES/defs/2.3.4-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.4-railsexpress
+++ b/SOURCES/defs/2.3.4-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.4-p0.7z" "2b460e3c79a0474030546caad9e66ba0e4be493f"
   package: "ruby-2.3.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.gz" "d064b9c69329ca2eb2956ad57b7192184178e35d"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.4-p0.7z" "2b460e3c79a0474030546caad9e66ba0e4be493f"
   package: "ruby-2.3.4-p0" "https://ruby.kaos.st/ruby-2.3.4.7z" "905d314446a2f80bfabd72a3ee080a79f378b743"

--- a/SOURCES/defs/2.3.5
+++ b/SOURCES/defs/2.3.5
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.5
+++ b/SOURCES/defs/2.3.5
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.gz" "3247e217d6745c27ef23bdc77b6abdb4b57a118f"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.5-p0" "https://ruby.kaos.st/ruby-2.3.5.7z" "d36aaea473e792de099d43f6cc77290c5264449f"

--- a/SOURCES/defs/2.3.5-jemalloc
+++ b/SOURCES/defs/2.3.5-jemalloc
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel

--- a/SOURCES/defs/2.3.5-jemalloc
+++ b/SOURCES/defs/2.3.5-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.5-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.gz" "3247e217d6745c27ef23bdc77b6abdb4b57a118f"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.5-p0" "https://ruby.kaos.st/ruby-2.3.5.7z" "d36aaea473e792de099d43f6cc77290c5264449f"

--- a/SOURCES/defs/2.3.5-railsexpress
+++ b/SOURCES/defs/2.3.5-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.5-railsexpress
+++ b/SOURCES/defs/2.3.5-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.5-p0.7z" "d279b3573a031c042357d78a4d8e8d1834944ca9"
   package: "ruby-2.3.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.gz" "3247e217d6745c27ef23bdc77b6abdb4b57a118f"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.5-p0.7z" "d279b3573a031c042357d78a4d8e8d1834944ca9"
   package: "ruby-2.3.5-p0" "https://ruby.kaos.st/ruby-2.3.5.7z" "d36aaea473e792de099d43f6cc77290c5264449f"

--- a/SOURCES/defs/2.3.6
+++ b/SOURCES/defs/2.3.6
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.6
+++ b/SOURCES/defs/2.3.6
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.gz" "4e6a0f828819e15d274ae58485585fc8b7caace0"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.6-p0" "https://ruby.kaos.st/ruby-2.3.6.7z" "f9e9508194a087b62ef4f656732087f15573e607"

--- a/SOURCES/defs/2.3.6-jemalloc
+++ b/SOURCES/defs/2.3.6-jemalloc
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel

--- a/SOURCES/defs/2.3.6-jemalloc
+++ b/SOURCES/defs/2.3.6-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.6-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.gz" "4e6a0f828819e15d274ae58485585fc8b7caace0"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.6-p0" "https://ruby.kaos.st/ruby-2.3.6.7z" "f9e9508194a087b62ef4f656732087f15573e607"

--- a/SOURCES/defs/2.3.6-railsexpress
+++ b/SOURCES/defs/2.3.6-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.6-railsexpress
+++ b/SOURCES/defs/2.3.6-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.6-p0.7z" "451b939ed5478ea077f82b30fde4d93424448bde"
   package: "ruby-2.3.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.gz" "4e6a0f828819e15d274ae58485585fc8b7caace0"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.6-p0.7z" "451b939ed5478ea077f82b30fde4d93424448bde"
   package: "ruby-2.3.6-p0" "https://ruby.kaos.st/ruby-2.3.6.7z" "f9e9508194a087b62ef4f656732087f15573e607"

--- a/SOURCES/defs/2.3.7
+++ b/SOURCES/defs/2.3.7
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.7
+++ b/SOURCES/defs/2.3.7
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.gz" "540996fec64984ab6099e34d2f5820b14904f15a"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.7-p0" "https://ruby.kaos.st/ruby-2.3.7.7z" "34b011ba4531782dfa21e8f8415cca86de8578e0"

--- a/SOURCES/defs/2.3.7-jemalloc
+++ b/SOURCES/defs/2.3.7-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.7-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.gz" "540996fec64984ab6099e34d2f5820b14904f15a"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.7-p0" "https://ruby.kaos.st/ruby-2.3.7.7z" "34b011ba4531782dfa21e8f8415cca86de8578e0"

--- a/SOURCES/defs/2.3.7-jemalloc
+++ b/SOURCES/defs/2.3.7-jemalloc
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:47 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel

--- a/SOURCES/defs/2.3.7-railsexpress
+++ b/SOURCES/defs/2.3.7-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.7-p0.7z" "bf430091089630e0f7b1982bed013ba7adb33db8"
   package: "ruby-2.3.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.gz" "540996fec64984ab6099e34d2f5820b14904f15a"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.7-p0.7z" "bf430091089630e0f7b1982bed013ba7adb33db8"
   package: "ruby-2.3.7-p0" "https://ruby.kaos.st/ruby-2.3.7.7z" "34b011ba4531782dfa21e8f8415cca86de8578e0"

--- a/SOURCES/defs/2.3.7-railsexpress
+++ b/SOURCES/defs/2.3.7-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.8
+++ b/SOURCES/defs/2.3.8
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.8
+++ b/SOURCES/defs/2.3.8
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,16 +8,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.8-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.8-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.8.tar.gz" "69311991a9cd2c8e3c86a0dbbaaf915ae91f0bec"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.8-p0" "https://ruby.kaos.st/ruby-2.3.8.7z" "f137fb989fb1540b2db933678d1b2b557d08be3e"

--- a/SOURCES/defs/2.3.8-jemalloc
+++ b/SOURCES/defs/2.3.8-jemalloc
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel

--- a/SOURCES/defs/2.3.8-jemalloc
+++ b/SOURCES/defs/2.3.8-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.8-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   package: "ruby-2.3.8-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.8.tar.gz" "69311991a9cd2c8e3c86a0dbbaaf915ae91f0bec"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   package: "ruby-2.3.8-p0" "https://ruby.kaos.st/ruby-2.3.8.7z" "f137fb989fb1540b2db933678d1b2b557d08be3e"

--- a/SOURCES/defs/2.3.8-railsexpress
+++ b/SOURCES/defs/2.3.8-railsexpress
@@ -2,6 +2,7 @@
 # UPDATED 06/Feb/2021 01:30:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
+eol(security): 2019-03-31
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel

--- a/SOURCES/defs/2.3.8-railsexpress
+++ b/SOURCES/defs/2.3.8-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 21/Sep/2019 01:27:06 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:30:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 
@@ -8,18 +8,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.0.2t): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.0.2t): -j 1
-PREFIX(openssl-1.0.2t): {prefix}/openssl
+CONFOPTS(openssl-1.0.2u): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.0.2u): -j 1
+PREFIX(openssl-1.0.2u): {prefix}/openssl
 
 CONFOPTS(ruby-2.3.8-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.0.2t" "https://www.openssl.org/source/openssl-1.0.2t.tar.gz" "8ac3fd379cf8c8ef570abb51ec52a88fd526f88a" openssl
+  package: "openssl-1.0.2u" "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz" "740916d79ab0d209d2775277b1c6c3ec2f6502b2" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.8-p0.7z" "e9e8f5e19cfce7e1a2c22a90bbc44a2b36570788"
   package: "ruby-2.3.8-p0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.8.tar.gz" "69311991a9cd2c8e3c86a0dbbaaf915ae91f0bec"
 
 [essentialkaos]
-  package: "openssl-1.0.2t" "https://ruby.kaos.st/openssl-1.0.2t.7z" "84718d07fb7dad142bc4b5b3c0cfd10858afef8f" openssl
+  package: "openssl-1.0.2u" "https://ruby.kaos.st/openssl-1.0.2u.7z" "d69744009cbcbeeedcc5825bfc65fa44361215ce" openssl
   patchset: "https://ruby.kaos.st/patches/2.3.8-p0.7z" "e9e8f5e19cfce7e1a2c22a90bbc44a2b36570788"
   package: "ruby-2.3.8-p0" "https://ruby.kaos.st/ruby-2.3.8.7z" "f137fb989fb1540b2db933678d1b2b557d08be3e"

--- a/SOURCES/defs/2.4.0
+++ b/SOURCES/defs/2.4.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.0
+++ b/SOURCES/defs/2.4.0
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:02 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.gz" "d44a3c50a0e742341ed3033d5db79d865151a4f4"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.0-p0" "https://ruby.kaos.st/ruby-2.4.0.7z" "04ea478c6645fc46506ec000f514deaed91d98e3"

--- a/SOURCES/defs/2.4.0-jemalloc
+++ b/SOURCES/defs/2.4.0-jemalloc
@@ -1,19 +1,19 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:02 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.0-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.gz" "d44a3c50a0e742341ed3033d5db79d865151a4f4"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.0-p0" "https://ruby.kaos.st/ruby-2.4.0.7z" "04ea478c6645fc46506ec000f514deaed91d98e3"

--- a/SOURCES/defs/2.4.0-jemalloc
+++ b/SOURCES/defs/2.4.0-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.4.0-railsexpress
+++ b/SOURCES/defs/2.4.0-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:02 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.0-p0.7z" "c1317a0ad3e0eddf51782d44825fb1ebbef1610f"
   package: "ruby-2.4.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.gz" "d44a3c50a0e742341ed3033d5db79d865151a4f4"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.0-p0.7z" "c1317a0ad3e0eddf51782d44825fb1ebbef1610f"
   package: "ruby-2.4.0-p0" "https://ruby.kaos.st/ruby-2.4.0.7z" "04ea478c6645fc46506ec000f514deaed91d98e3"

--- a/SOURCES/defs/2.4.0-railsexpress
+++ b/SOURCES/defs/2.4.0-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.1
+++ b/SOURCES/defs/2.4.1
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.1
+++ b/SOURCES/defs/2.4.1
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:02 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.gz" "47909a0f77ea900573f027d27746960ad6d07d15"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.1-p0" "https://ruby.kaos.st/ruby-2.4.1.7z" "945e24c959c6a803d27448a7ee452119592dd132"

--- a/SOURCES/defs/2.4.1-jemalloc
+++ b/SOURCES/defs/2.4.1-jemalloc
@@ -1,19 +1,19 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:02 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.1-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.gz" "47909a0f77ea900573f027d27746960ad6d07d15"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.1-p0" "https://ruby.kaos.st/ruby-2.4.1.7z" "945e24c959c6a803d27448a7ee452119592dd132"

--- a/SOURCES/defs/2.4.1-jemalloc
+++ b/SOURCES/defs/2.4.1-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.4.1-railsexpress
+++ b/SOURCES/defs/2.4.1-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:02 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.1-p0.7z" "23adaf9d672104319439eda723072ad1beba3d76"
   package: "ruby-2.4.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.gz" "47909a0f77ea900573f027d27746960ad6d07d15"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.1-p0.7z" "23adaf9d672104319439eda723072ad1beba3d76"
   package: "ruby-2.4.1-p0" "https://ruby.kaos.st/ruby-2.4.1.7z" "945e24c959c6a803d27448a7ee452119592dd132"

--- a/SOURCES/defs/2.4.1-railsexpress
+++ b/SOURCES/defs/2.4.1-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.2
+++ b/SOURCES/defs/2.4.2
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.2
+++ b/SOURCES/defs/2.4.2
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:02 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz" "b096124469e31e4fc3d00d2b61b11d36992e6bbd"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.2-p0" "https://ruby.kaos.st/ruby-2.4.2.7z" "eeaca7e29fb059dec33e1bb41c25eec80f577266"

--- a/SOURCES/defs/2.4.2-jemalloc
+++ b/SOURCES/defs/2.4.2-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.4.2-jemalloc
+++ b/SOURCES/defs/2.4.2-jemalloc
@@ -1,19 +1,19 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:02 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.2-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz" "b096124469e31e4fc3d00d2b61b11d36992e6bbd"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.2-p0" "https://ruby.kaos.st/ruby-2.4.2.7z" "eeaca7e29fb059dec33e1bb41c25eec80f577266"

--- a/SOURCES/defs/2.4.2-railsexpress
+++ b/SOURCES/defs/2.4.2-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:02 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.2-p0.7z" "9753df86aaa42e5f0262fbd7ea6449bed8f2a29a"
   package: "ruby-2.4.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz" "b096124469e31e4fc3d00d2b61b11d36992e6bbd"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.2-p0.7z" "9753df86aaa42e5f0262fbd7ea6449bed8f2a29a"
   package: "ruby-2.4.2-p0" "https://ruby.kaos.st/ruby-2.4.2.7z" "eeaca7e29fb059dec33e1bb41c25eec80f577266"

--- a/SOURCES/defs/2.4.2-railsexpress
+++ b/SOURCES/defs/2.4.2-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc git make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.3
+++ b/SOURCES/defs/2.4.3
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.3
+++ b/SOURCES/defs/2.4.3
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:02 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.gz" "787b7f4e90fb4b39a61bc1a31eb7765f875a590c"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.3-p0" "https://ruby.kaos.st/ruby-2.4.3.7z" "1cd2dfe3c7e4329d37935ff875419d6cebbd7170"

--- a/SOURCES/defs/2.4.3-jemalloc
+++ b/SOURCES/defs/2.4.3-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.4.3-jemalloc
+++ b/SOURCES/defs/2.4.3-jemalloc
@@ -1,19 +1,19 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:02 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.3-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.gz" "787b7f4e90fb4b39a61bc1a31eb7765f875a590c"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.3-p0" "https://ruby.kaos.st/ruby-2.4.3.7z" "1cd2dfe3c7e4329d37935ff875419d6cebbd7170"

--- a/SOURCES/defs/2.4.3-railsexpress
+++ b/SOURCES/defs/2.4.3-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.3-p0.7z" "82a23b845ece89ac05cc36008a9de22dea6a0f2d"
   package: "ruby-2.4.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.gz" "787b7f4e90fb4b39a61bc1a31eb7765f875a590c"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.3-p0.7z" "82a23b845ece89ac05cc36008a9de22dea6a0f2d"
   package: "ruby-2.4.3-p0" "https://ruby.kaos.st/ruby-2.4.3.7z" "1cd2dfe3c7e4329d37935ff875419d6cebbd7170"

--- a/SOURCES/defs/2.4.3-railsexpress
+++ b/SOURCES/defs/2.4.3-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.4
+++ b/SOURCES/defs/2.4.4
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.4
+++ b/SOURCES/defs/2.4.4
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.gz" "ec82b0d53bd0adad9b19e6b45e44d54e9ec3f10c"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.4-p0" "https://ruby.kaos.st/ruby-2.4.4.7z" "ca54892a46ad75e18596930ebf682214ce0db886"

--- a/SOURCES/defs/2.4.4-jemalloc
+++ b/SOURCES/defs/2.4.4-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.4.4-jemalloc
+++ b/SOURCES/defs/2.4.4-jemalloc
@@ -1,19 +1,19 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.4-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.gz" "ec82b0d53bd0adad9b19e6b45e44d54e9ec3f10c"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.4-p0" "https://ruby.kaos.st/ruby-2.4.4.7z" "ca54892a46ad75e18596930ebf682214ce0db886"

--- a/SOURCES/defs/2.4.4-railsexpress
+++ b/SOURCES/defs/2.4.4-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.4-railsexpress
+++ b/SOURCES/defs/2.4.4-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.4-p0.7z" "0e8793d77ea95826982763737779cfed1ac5d2e9"
   package: "ruby-2.4.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.gz" "ec82b0d53bd0adad9b19e6b45e44d54e9ec3f10c"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.4-p0.7z" "0e8793d77ea95826982763737779cfed1ac5d2e9"
   package: "ruby-2.4.4-p0" "https://ruby.kaos.st/ruby-2.4.4.7z" "ca54892a46ad75e18596930ebf682214ce0db886"

--- a/SOURCES/defs/2.4.5
+++ b/SOURCES/defs/2.4.5
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.gz" "4d650f302f1ec00256450b112bb023644b6ab6dd"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.5-p0" "https://ruby.kaos.st/ruby-2.4.5.7z" "5b84b9806c2e651582ee8033c3d0e9c148c11d9b"

--- a/SOURCES/defs/2.4.5
+++ b/SOURCES/defs/2.4.5
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.5-jemalloc
+++ b/SOURCES/defs/2.4.5-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.4.5-jemalloc
+++ b/SOURCES/defs/2.4.5-jemalloc
@@ -1,19 +1,19 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.5-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.gz" "4d650f302f1ec00256450b112bb023644b6ab6dd"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.5-p0" "https://ruby.kaos.st/ruby-2.4.5.7z" "5b84b9806c2e651582ee8033c3d0e9c148c11d9b"

--- a/SOURCES/defs/2.4.5-railsexpress
+++ b/SOURCES/defs/2.4.5-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.5-p0.7z" "ac9eea5118f483bc278ace43119e4a2b12a73670"
   package: "ruby-2.4.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.gz" "4d650f302f1ec00256450b112bb023644b6ab6dd"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.5-p0.7z" "ac9eea5118f483bc278ace43119e4a2b12a73670"
   package: "ruby-2.4.5-p0" "https://ruby.kaos.st/ruby-2.4.5.7z" "5b84b9806c2e651582ee8033c3d0e9c148c11d9b"

--- a/SOURCES/defs/2.4.5-railsexpress
+++ b/SOURCES/defs/2.4.5-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.6
+++ b/SOURCES/defs/2.4.6
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.6
+++ b/SOURCES/defs/2.4.6
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.gz" "3bc2d9ab3381887c57e0fb7937dc14e9f419f06c"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.6-p0" "https://ruby.kaos.st/ruby-2.4.6.7z" "68f9fbc4de6e9681452832febcd72ee6c27d69f4"

--- a/SOURCES/defs/2.4.6-jemalloc
+++ b/SOURCES/defs/2.4.6-jemalloc
@@ -1,19 +1,19 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.6-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.gz" "3bc2d9ab3381887c57e0fb7937dc14e9f419f06c"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.6-p0" "https://ruby.kaos.st/ruby-2.4.6.7z" "68f9fbc4de6e9681452832febcd72ee6c27d69f4"

--- a/SOURCES/defs/2.4.6-jemalloc
+++ b/SOURCES/defs/2.4.6-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.4.6-railsexpress
+++ b/SOURCES/defs/2.4.6-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.6-p0.7z" "bfa5d520a9aae7b10add7e7d5d1187971db34bd5"
   package: "ruby-2.4.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.gz" "3bc2d9ab3381887c57e0fb7937dc14e9f419f06c"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.6-p0.7z" "bfa5d520a9aae7b10add7e7d5d1187971db34bd5"
   package: "ruby-2.4.6-p0" "https://ruby.kaos.st/ruby-2.4.6.7z" "68f9fbc4de6e9681452832febcd72ee6c27d69f4"

--- a/SOURCES/defs/2.4.6-railsexpress
+++ b/SOURCES/defs/2.4.6-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.7
+++ b/SOURCES/defs/2.4.7
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.7
+++ b/SOURCES/defs/2.4.7
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz" "607384450348bd87028cd8d1ebf09f21103d0cd2"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.7-p0" "https://ruby.kaos.st/ruby-2.4.7.7z" "2a8d8fcc4cb62f6f30246b38d9999764a6332f96"

--- a/SOURCES/defs/2.4.7-jemalloc
+++ b/SOURCES/defs/2.4.7-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.4.7-jemalloc
+++ b/SOURCES/defs/2.4.7-jemalloc
@@ -1,19 +1,19 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.7-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz" "607384450348bd87028cd8d1ebf09f21103d0cd2"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.7-p0" "https://ruby.kaos.st/ruby-2.4.7.7z" "2a8d8fcc4cb62f6f30246b38d9999764a6332f96"

--- a/SOURCES/defs/2.4.9
+++ b/SOURCES/defs/2.4.9
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.9
+++ b/SOURCES/defs/2.4.9
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.9-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.9-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.gz" "da07b802cf7598547f98b7b2d8fc8ff5f03dbef4"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.9-p0" "https://ruby.kaos.st/ruby-2.4.9.7z" "4112c40582b482e8812f349edd415d0427b5db9c"

--- a/SOURCES/defs/2.4.9-jemalloc
+++ b/SOURCES/defs/2.4.9-jemalloc
@@ -1,19 +1,19 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.9-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.4.9-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.gz" "da07b802cf7598547f98b7b2d8fc8ff5f03dbef4"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.4.9-p0" "https://ruby.kaos.st/ruby-2.4.9.7z" "4112c40582b482e8812f349edd415d0427b5db9c"

--- a/SOURCES/defs/2.4.9-jemalloc
+++ b/SOURCES/defs/2.4.9-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.4.9-railsexpress
+++ b/SOURCES/defs/2.4.9-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2019-03-31
+eol(security): 2020-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.4.9-railsexpress
+++ b/SOURCES/defs/2.4.9-railsexpress
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.9-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.9-p0.7z" "79fee10ec597308c97804fe5653c8a7f479bc54c"
   package: "ruby-2.4.9-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.gz" "da07b802cf7598547f98b7b2d8fc8ff5f03dbef4"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.9-p0.7z" "79fee10ec597308c97804fe5653c8a7f479bc54c"
   package: "ruby-2.4.9-p0" "https://ruby.kaos.st/ruby-2.4.9.7z" "4112c40582b482e8812f349edd415d0427b5db9c"

--- a/SOURCES/defs/2.5.0
+++ b/SOURCES/defs/2.5.0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.0-p0): --with-openssl-dir={prefix}/openssl --with-baseruby={ruby_bin} --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patch: "https://github.com/ruby/ruby/commit/de11e472b447df6d45cd2eaa577d0f2f1efd4064.patch" "4bd7b9e2893f56b6833a16be52f64193b6c02ed1"
   package: "ruby-2.5.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.gz" "58f77301c891c1c4a08f301861c26b1ea46509f6"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patch: "https://github.com/ruby/ruby/commit/de11e472b447df6d45cd2eaa577d0f2f1efd4064.patch" "4bd7b9e2893f56b6833a16be52f64193b6c02ed1"
   package: "ruby-2.5.0-p0" "https://ruby.kaos.st/ruby-2.5.0.7z" "018048c1ceb894762631393427ffcf354db40af7"

--- a/SOURCES/defs/2.5.0
+++ b/SOURCES/defs/2.5.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.0-jemalloc
+++ b/SOURCES/defs/2.5.0-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.5.0-jemalloc
+++ b/SOURCES/defs/2.5.0-jemalloc
@@ -1,23 +1,23 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.0-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --with-baseruby={ruby_bin} --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patch: "https://github.com/ruby/ruby/commit/de11e472b447df6d45cd2eaa577d0f2f1efd4064.patch" "4bd7b9e2893f56b6833a16be52f64193b6c02ed1"
   package: "ruby-2.5.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.gz" "58f77301c891c1c4a08f301861c26b1ea46509f6"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patch: "https://github.com/ruby/ruby/commit/de11e472b447df6d45cd2eaa577d0f2f1efd4064.patch" "4bd7b9e2893f56b6833a16be52f64193b6c02ed1"
   package: "ruby-2.5.0-p0" "https://ruby.kaos.st/ruby-2.5.0.7z" "018048c1ceb894762631393427ffcf354db40af7"

--- a/SOURCES/defs/2.5.0-railsexpress
+++ b/SOURCES/defs/2.5.0-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,20 +8,20 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.0-p0): --with-openssl-dir={prefix}/openssl --with-baseruby={ruby_bin} --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patch: "https://github.com/ruby/ruby/commit/de11e472b447df6d45cd2eaa577d0f2f1efd4064.patch" "4bd7b9e2893f56b6833a16be52f64193b6c02ed1"
   patchset: "https://ruby.kaos.st/patches/2.5.0-p0.7z" "52388c989f89b77b98d2cfdf374ac5e6f596dfb0"
   package: "ruby-2.5.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.gz" "58f77301c891c1c4a08f301861c26b1ea46509f6"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patch: "https://github.com/ruby/ruby/commit/de11e472b447df6d45cd2eaa577d0f2f1efd4064.patch" "4bd7b9e2893f56b6833a16be52f64193b6c02ed1"
   patchset: "https://ruby.kaos.st/patches/2.5.0-p0.7z" "52388c989f89b77b98d2cfdf374ac5e6f596dfb0"
   package: "ruby-2.5.0-p0" "https://ruby.kaos.st/ruby-2.5.0.7z" "018048c1ceb894762631393427ffcf354db40af7"

--- a/SOURCES/defs/2.5.0-railsexpress
+++ b/SOURCES/defs/2.5.0-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.1
+++ b/SOURCES/defs/2.5.1
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.gz" "93fafd57a724974b951957c522cdc4478a6bdc2e"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.1-p0" "https://ruby.kaos.st/ruby-2.5.1.7z" "324911ba95363737825c0c748da6552d7a33f114"

--- a/SOURCES/defs/2.5.1
+++ b/SOURCES/defs/2.5.1
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.1-jemalloc
+++ b/SOURCES/defs/2.5.1-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.1-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.gz" "93fafd57a724974b951957c522cdc4478a6bdc2e"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.1-p0" "https://ruby.kaos.st/ruby-2.5.1.7z" "324911ba95363737825c0c748da6552d7a33f114"

--- a/SOURCES/defs/2.5.1-jemalloc
+++ b/SOURCES/defs/2.5.1-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.5.1-railsexpress
+++ b/SOURCES/defs/2.5.1-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:03 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.1-p0.7z" "e77a8d22b508e0c260f234233ccb2f980188be8b"
   package: "ruby-2.5.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.gz" "93fafd57a724974b951957c522cdc4478a6bdc2e"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.1-p0.7z" "e77a8d22b508e0c260f234233ccb2f980188be8b"
   package: "ruby-2.5.1-p0" "https://ruby.kaos.st/ruby-2.5.1.7z" "324911ba95363737825c0c748da6552d7a33f114"

--- a/SOURCES/defs/2.5.1-railsexpress
+++ b/SOURCES/defs/2.5.1-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.2
+++ b/SOURCES/defs/2.5.2
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.2.tar.gz" "7e503e75621b69cedb1d8b3fa2bee5aef2f1a714"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.2-p0" "https://ruby.kaos.st/ruby-2.5.2.7z" "4a8c45bdcf33b481970610d19f796fa835d30f4f"

--- a/SOURCES/defs/2.5.2
+++ b/SOURCES/defs/2.5.2
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.2-jemalloc
+++ b/SOURCES/defs/2.5.2-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.5.2-jemalloc
+++ b/SOURCES/defs/2.5.2-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.2-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.2.tar.gz" "7e503e75621b69cedb1d8b3fa2bee5aef2f1a714"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.2-p0" "https://ruby.kaos.st/ruby-2.5.2.7z" "4a8c45bdcf33b481970610d19f796fa835d30f4f"

--- a/SOURCES/defs/2.5.3
+++ b/SOURCES/defs/2.5.3
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.gz" "f919a9fbcdb7abecd887157b49833663c5c15fda"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.3-p0" "https://ruby.kaos.st/ruby-2.5.3.7z" "8d95f53cc308a0e55ec90d75704e0a087b1eda0c"

--- a/SOURCES/defs/2.5.3
+++ b/SOURCES/defs/2.5.3
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.3-jemalloc
+++ b/SOURCES/defs/2.5.3-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.5.3-jemalloc
+++ b/SOURCES/defs/2.5.3-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.3-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.gz" "f919a9fbcdb7abecd887157b49833663c5c15fda"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.3-p0" "https://ruby.kaos.st/ruby-2.5.3.7z" "8d95f53cc308a0e55ec90d75704e0a087b1eda0c"

--- a/SOURCES/defs/2.5.3-railsexpress
+++ b/SOURCES/defs/2.5.3-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.3-p0.7z" "c016845495ea8487e38a2509cdbcad7540d7e041"
   package: "ruby-2.5.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.gz" "f919a9fbcdb7abecd887157b49833663c5c15fda"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.3-p0.7z" "c016845495ea8487e38a2509cdbcad7540d7e041"
   package: "ruby-2.5.3-p0" "https://ruby.kaos.st/ruby-2.5.3.7z" "8d95f53cc308a0e55ec90d75704e0a087b1eda0c"

--- a/SOURCES/defs/2.5.3-railsexpress
+++ b/SOURCES/defs/2.5.3-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.4
+++ b/SOURCES/defs/2.5.4
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.gz" "330bb5472f565b683c7f8c9091d4ee0cc155b51b"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.4-p0" "https://ruby.kaos.st/ruby-2.5.4.7z" "038286f2468ddc6f40bcb54e2b2199ef984289e5"

--- a/SOURCES/defs/2.5.4
+++ b/SOURCES/defs/2.5.4
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.4-jemalloc
+++ b/SOURCES/defs/2.5.4-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.4-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.gz" "330bb5472f565b683c7f8c9091d4ee0cc155b51b"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.4-p0" "https://ruby.kaos.st/ruby-2.5.4.7z" "038286f2468ddc6f40bcb54e2b2199ef984289e5"

--- a/SOURCES/defs/2.5.4-jemalloc
+++ b/SOURCES/defs/2.5.4-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.5.4-railsexpress
+++ b/SOURCES/defs/2.5.4-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.4-p0.7z" "e6a917cca85d9b2554d44349d7cb505c33a9a44f"
   package: "ruby-2.5.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.gz" "330bb5472f565b683c7f8c9091d4ee0cc155b51b"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.4-p0.7z" "e6a917cca85d9b2554d44349d7cb505c33a9a44f"
   package: "ruby-2.5.4-p0" "https://ruby.kaos.st/ruby-2.5.4.7z" "038286f2468ddc6f40bcb54e2b2199ef984289e5"

--- a/SOURCES/defs/2.5.4-railsexpress
+++ b/SOURCES/defs/2.5.4-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.5
+++ b/SOURCES/defs/2.5.5
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.gz" "e6a063728950762925108abbdbf68968ec1ab5bb"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.5-p0" "https://ruby.kaos.st/ruby-2.5.5.7z" "b107f4d615e43f60d6ebc33ae1621909fe3e708d"

--- a/SOURCES/defs/2.5.5
+++ b/SOURCES/defs/2.5.5
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.5-jemalloc
+++ b/SOURCES/defs/2.5.5-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.5.5-jemalloc
+++ b/SOURCES/defs/2.5.5-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.5-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.gz" "e6a063728950762925108abbdbf68968ec1ab5bb"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.5-p0" "https://ruby.kaos.st/ruby-2.5.5.7z" "b107f4d615e43f60d6ebc33ae1621909fe3e708d"

--- a/SOURCES/defs/2.5.5-railsexpress
+++ b/SOURCES/defs/2.5.5-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.5-p0.7z" "32ff7f8c7cf47a72037c1e96e75023b88b55757b"
   package: "ruby-2.5.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.gz" "e6a063728950762925108abbdbf68968ec1ab5bb"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.5-p0.7z" "32ff7f8c7cf47a72037c1e96e75023b88b55757b"
   package: "ruby-2.5.5-p0" "https://ruby.kaos.st/ruby-2.5.5.7z" "b107f4d615e43f60d6ebc33ae1621909fe3e708d"

--- a/SOURCES/defs/2.5.5-railsexpress
+++ b/SOURCES/defs/2.5.5-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.6
+++ b/SOURCES/defs/2.5.6
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz" "d2dd34da5f3b63a0075e50133f60eb35d71b7543"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.6-p0" "https://ruby.kaos.st/ruby-2.5.6.7z" "a31c2f1299e6a5b8790ebfecf84670313037063a"

--- a/SOURCES/defs/2.5.6
+++ b/SOURCES/defs/2.5.6
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.6-jemalloc
+++ b/SOURCES/defs/2.5.6-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.5.6-jemalloc
+++ b/SOURCES/defs/2.5.6-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.6-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz" "d2dd34da5f3b63a0075e50133f60eb35d71b7543"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.6-p0" "https://ruby.kaos.st/ruby-2.5.6.7z" "a31c2f1299e6a5b8790ebfecf84670313037063a"

--- a/SOURCES/defs/2.5.6-railsexpress
+++ b/SOURCES/defs/2.5.6-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.6-p0.7z" "7484b0e2ba0987c66bf3b034f9f8c9615952e0bd"
   package: "ruby-2.5.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz" "d2dd34da5f3b63a0075e50133f60eb35d71b7543"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.6-p0.7z" "7484b0e2ba0987c66bf3b034f9f8c9615952e0bd"
   package: "ruby-2.5.6-p0" "https://ruby.kaos.st/ruby-2.5.6.7z" "a31c2f1299e6a5b8790ebfecf84670313037063a"

--- a/SOURCES/defs/2.5.6-railsexpress
+++ b/SOURCES/defs/2.5.6-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.7
+++ b/SOURCES/defs/2.5.7
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.gz" "541039290d188fff683a1d2f2892bd74854dd022"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.7-p0" "https://ruby.kaos.st/ruby-2.5.7.7z" "0b4aa716b9e800cb333d9280e72b8f03fbdb5746"

--- a/SOURCES/defs/2.5.7
+++ b/SOURCES/defs/2.5.7
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.7-jemalloc
+++ b/SOURCES/defs/2.5.7-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.5.7-jemalloc
+++ b/SOURCES/defs/2.5.7-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.7-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.gz" "541039290d188fff683a1d2f2892bd74854dd022"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.7-p0" "https://ruby.kaos.st/ruby-2.5.7.7z" "0b4aa716b9e800cb333d9280e72b8f03fbdb5746"

--- a/SOURCES/defs/2.5.7-railsexpress
+++ b/SOURCES/defs/2.5.7-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.7-p0.7z" "b75fa2333435a786909ef9d48598d2b9e663f9d9"
   package: "ruby-2.5.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.gz" "541039290d188fff683a1d2f2892bd74854dd022"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.7-p0.7z" "b75fa2333435a786909ef9d48598d2b9e663f9d9"
   package: "ruby-2.5.7-p0" "https://ruby.kaos.st/ruby-2.5.7.7z" "0b4aa716b9e800cb333d9280e72b8f03fbdb5746"

--- a/SOURCES/defs/2.5.7-railsexpress
+++ b/SOURCES/defs/2.5.7-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.8
+++ b/SOURCES/defs/2.5.8
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:57:51 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.8-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.8-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.gz" "71e7b22d1dfa32d3df0bfeec48237b28a53bc04f"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.8-p0" "https://ruby.kaos.st/ruby-2.5.8.7z" "17df6dc748a4e94be31f469dbede4bfeceb13994"

--- a/SOURCES/defs/2.5.8
+++ b/SOURCES/defs/2.5.8
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.5.8-jemalloc
+++ b/SOURCES/defs/2.5.8-jemalloc
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 

--- a/SOURCES/defs/2.5.8-jemalloc
+++ b/SOURCES/defs/2.5.8-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:57:51 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.8-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.5.8-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.gz" "71e7b22d1dfa32d3df0bfeec48237b28a53bc04f"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.5.8-p0" "https://ruby.kaos.st/ruby-2.5.8.7z" "17df6dc748a4e94be31f469dbede4bfeceb13994"

--- a/SOURCES/defs/2.5.8-railsexpress
+++ b/SOURCES/defs/2.5.8-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:57:52 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.8-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.8-p0.7z" "3b9db5a1e5c94435d598dda73019d5e323fd253c"
   package: "ruby-2.5.8-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.gz" "71e7b22d1dfa32d3df0bfeec48237b28a53bc04f"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.8-p0.7z" "3b9db5a1e5c94435d598dda73019d5e323fd253c"
   package: "ruby-2.5.8-p0" "https://ruby.kaos.st/ruby-2.5.8.7z" "17df6dc748a4e94be31f469dbede4bfeceb13994"

--- a/SOURCES/defs/2.5.8-railsexpress
+++ b/SOURCES/defs/2.5.8-railsexpress
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2020-03-31
+eol(security): 2021-03-31
+
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates

--- a/SOURCES/defs/2.6.0
+++ b/SOURCES/defs/2.6.0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.gz" "c95f4e86e21390270dad3ebb94491fd42ee2ce69"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
   package: "ruby-2.6.0-p0" "https://ruby.kaos.st/ruby-2.6.0.7z" "f1d5a0559236d20736e9bcc7c2aca5aec073da30"

--- a/SOURCES/defs/2.6.0-jemalloc
+++ b/SOURCES/defs/2.6.0-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.0-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.gz" "c95f4e86e21390270dad3ebb94491fd42ee2ce69"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
   package: "ruby-2.6.0-p0" "https://ruby.kaos.st/ruby-2.6.0.7z" "f1d5a0559236d20736e9bcc7c2aca5aec073da30"

--- a/SOURCES/defs/2.6.0-railsexpress
+++ b/SOURCES/defs/2.6.0-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.0-p0.7z" "9bb4a1eb091339d0a507c23e49cda998b4ac9f1e"
   package: "ruby-2.6.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.gz" "c95f4e86e21390270dad3ebb94491fd42ee2ce69"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.0-p0.7z" "9bb4a1eb091339d0a507c23e49cda998b4ac9f1e"
   package: "ruby-2.6.0-p0" "https://ruby.kaos.st/ruby-2.6.0.7z" "f1d5a0559236d20736e9bcc7c2aca5aec073da30"

--- a/SOURCES/defs/2.6.1
+++ b/SOURCES/defs/2.6.1
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.gz" "416842bb5b4ca655610df1f0389b6e21d25154f8"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
   package: "ruby-2.6.1-p0" "https://ruby.kaos.st/ruby-2.6.1.7z" "5048182d8fc4fc2b2c911ee5ca383a66ff2e14c7"

--- a/SOURCES/defs/2.6.1-jemalloc
+++ b/SOURCES/defs/2.6.1-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.1-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.gz" "416842bb5b4ca655610df1f0389b6e21d25154f8"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
   package: "ruby-2.6.1-p0" "https://ruby.kaos.st/ruby-2.6.1.7z" "5048182d8fc4fc2b2c911ee5ca383a66ff2e14c7"

--- a/SOURCES/defs/2.6.1-railsexpress
+++ b/SOURCES/defs/2.6.1-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.1-p0.7z" "68753d52cc43d46f7eb3c3cf6424ddd78ffc9669"
   package: "ruby-2.6.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.gz" "416842bb5b4ca655610df1f0389b6e21d25154f8"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.1-p0.7z" "68753d52cc43d46f7eb3c3cf6424ddd78ffc9669"
   package: "ruby-2.6.1-p0" "https://ruby.kaos.st/ruby-2.6.1.7z" "5048182d8fc4fc2b2c911ee5ca383a66ff2e14c7"

--- a/SOURCES/defs/2.6.2
+++ b/SOURCES/defs/2.6.2
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.gz" "44c6634a41f63ebdc1f3ce6ddcf48a4766bb4df7"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.6.2-p0" "https://ruby.kaos.st/ruby-2.6.2.7z" "c76b54231329fb63e0a9efd08b37b68f353824e2"

--- a/SOURCES/defs/2.6.2-jemalloc
+++ b/SOURCES/defs/2.6.2-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.2-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.gz" "44c6634a41f63ebdc1f3ce6ddcf48a4766bb4df7"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.6.2-p0" "https://ruby.kaos.st/ruby-2.6.2.7z" "c76b54231329fb63e0a9efd08b37b68f353824e2"

--- a/SOURCES/defs/2.6.2-railsexpress
+++ b/SOURCES/defs/2.6.2-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.2-p0.7z" "63ec31ecb3a4fab5ea209e32a9225cddf9a37c5e"
   package: "ruby-2.6.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.gz" "44c6634a41f63ebdc1f3ce6ddcf48a4766bb4df7"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.2-p0.7z" "63ec31ecb3a4fab5ea209e32a9225cddf9a37c5e"
   package: "ruby-2.6.2-p0" "https://ruby.kaos.st/ruby-2.6.2.7z" "c76b54231329fb63e0a9efd08b37b68f353824e2"

--- a/SOURCES/defs/2.6.3
+++ b/SOURCES/defs/2.6.3
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.gz" "2347ed6ca5490a104ebd5684d2b9b5eefa6cd33c"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.6.3-p0" "https://ruby.kaos.st/ruby-2.6.3.7z" "f44751129cd806ebe6eeedddf336b6fb4823be13"

--- a/SOURCES/defs/2.6.3-jemalloc
+++ b/SOURCES/defs/2.6.3-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.3-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.gz" "2347ed6ca5490a104ebd5684d2b9b5eefa6cd33c"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.6.3-p0" "https://ruby.kaos.st/ruby-2.6.3.7z" "f44751129cd806ebe6eeedddf336b6fb4823be13"

--- a/SOURCES/defs/2.6.3-railsexpress
+++ b/SOURCES/defs/2.6.3-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.3-p0.7z" "ea16bfddae3f33c54fd9bcc2e75340c20f441484"
   package: "ruby-2.6.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.gz" "2347ed6ca5490a104ebd5684d2b9b5eefa6cd33c"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.3-p0.7z" "ea16bfddae3f33c54fd9bcc2e75340c20f441484"
   package: "ruby-2.6.3-p0" "https://ruby.kaos.st/ruby-2.6.3.7z" "f44751129cd806ebe6eeedddf336b6fb4823be13"

--- a/SOURCES/defs/2.6.4
+++ b/SOURCES/defs/2.6.4
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.gz" "2eaddc428cb5d210cfc256a7e6947196ed24355b"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.6.4-p0" "https://ruby.kaos.st/ruby-2.6.4.7z" "61b6950d748fda8554781af27cf4a289ebc16dbf"

--- a/SOURCES/defs/2.6.4-jemalloc
+++ b/SOURCES/defs/2.6.4-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.4-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.gz" "2eaddc428cb5d210cfc256a7e6947196ed24355b"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.6.4-p0" "https://ruby.kaos.st/ruby-2.6.4.7z" "61b6950d748fda8554781af27cf4a289ebc16dbf"

--- a/SOURCES/defs/2.6.4-railsexpress
+++ b/SOURCES/defs/2.6.4-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.4-p0.7z" "4484dc90804167034faf9fa367ef1997b7de70d9"
   package: "ruby-2.6.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.gz" "2eaddc428cb5d210cfc256a7e6947196ed24355b"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.4-p0.7z" "4484dc90804167034faf9fa367ef1997b7de70d9"
   package: "ruby-2.6.4-p0" "https://ruby.kaos.st/ruby-2.6.4.7z" "61b6950d748fda8554781af27cf4a289ebc16dbf"

--- a/SOURCES/defs/2.6.5
+++ b/SOURCES/defs/2.6.5
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.gz" "1416ce288fb8bfeae07a12b608540318c9cace71"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.6.5-p0" "https://ruby.kaos.st/ruby-2.6.5.7z" "5994df0b447ca3c09900a76a9664cf6038033fe0"

--- a/SOURCES/defs/2.6.5-jemalloc
+++ b/SOURCES/defs/2.6.5-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.5-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.gz" "1416ce288fb8bfeae07a12b608540318c9cace71"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.6.5-p0" "https://ruby.kaos.st/ruby-2.6.5.7z" "5994df0b447ca3c09900a76a9664cf6038033fe0"

--- a/SOURCES/defs/2.6.5-railsexpress
+++ b/SOURCES/defs/2.6.5-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.5-p0.7z" "d1804925ffc759d567e2a3786c5c39b35802d837"
   package: "ruby-2.6.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.gz" "1416ce288fb8bfeae07a12b608540318c9cace71"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.5-p0.7z" "d1804925ffc759d567e2a3786c5c39b35802d837"
   package: "ruby-2.6.5-p0" "https://ruby.kaos.st/ruby-2.6.5.7z" "5994df0b447ca3c09900a76a9664cf6038033fe0"

--- a/SOURCES/defs/2.6.6
+++ b/SOURCES/defs/2.6.6
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:57:41 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.gz" "2d78048e293817f38d4ede4ebc7873013e97bb0b"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.6.6-p0" "https://ruby.kaos.st/ruby-2.6.6.7z" "40cb10841d58c2ef8252d6a1fd66bbd3101b6001"

--- a/SOURCES/defs/2.6.6-jemalloc
+++ b/SOURCES/defs/2.6.6-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:57:41 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.6-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.6.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.gz" "2d78048e293817f38d4ede4ebc7873013e97bb0b"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.6.6-p0" "https://ruby.kaos.st/ruby-2.6.6.7z" "40cb10841d58c2ef8252d6a1fd66bbd3101b6001"

--- a/SOURCES/defs/2.6.6-railsexpress
+++ b/SOURCES/defs/2.6.6-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:57:41 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.6-p0.7z" "16887e9d26a2d16742de1c86e6836c661894f6aa"
   package: "ruby-2.6.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.gz" "2d78048e293817f38d4ede4ebc7873013e97bb0b"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.6-p0.7z" "16887e9d26a2d16742de1c86e6836c661894f6aa"
   package: "ruby-2.6.6-p0" "https://ruby.kaos.st/ruby-2.6.6.7z" "40cb10841d58c2ef8252d6a1fd66bbd3101b6001"

--- a/SOURCES/defs/2.7.0
+++ b/SOURCES/defs/2.7.0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.7.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.gz" "6f4e99b5556010cb27e236873cb8c09eb8317cd5"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.7.0-p0" "https://ruby.kaos.st/ruby-2.7.0.7z" "72452dbd8eb883e962fa4bf370b352252848b842"

--- a/SOURCES/defs/2.7.0-jemalloc
+++ b/SOURCES/defs/2.7.0-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:58:05 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.0-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.7.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.gz" "6f4e99b5556010cb27e236873cb8c09eb8317cd5"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.7.0-p0" "https://ruby.kaos.st/ruby-2.7.0.7z" "72452dbd8eb883e962fa4bf370b352252848b842"

--- a/SOURCES/defs/2.7.0-railsexpress
+++ b/SOURCES/defs/2.7.0-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 01:03:23 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.7.0-p0.7z" "6bfb620b90b271a4907f00edcd8b978f38405814"
   package: "ruby-2.7.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.gz" "6f4e99b5556010cb27e236873cb8c09eb8317cd5"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.7.0-p0.7z" "6bfb620b90b271a4907f00edcd8b978f38405814"
   package: "ruby-2.7.0-p0" "https://ruby.kaos.st/ruby-2.7.0.7z" "72452dbd8eb883e962fa4bf370b352252848b842"

--- a/SOURCES/defs/2.7.1
+++ b/SOURCES/defs/2.7.1
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:57:34 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.7.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz" "76e25fce50a87f76a3ccd6d0fdd9b7c792400249"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.7.1-p0" "https://ruby.kaos.st/ruby-2.7.1.7z" "93e71b984173ed85bf8e3fa012f29170593cb371"

--- a/SOURCES/defs/2.7.1-jemalloc
+++ b/SOURCES/defs/2.7.1-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:57:35 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.1-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.7.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz" "76e25fce50a87f76a3ccd6d0fdd9b7c792400249"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.7.1-p0" "https://ruby.kaos.st/ruby-2.7.1.7z" "93e71b984173ed85bf8e3fa012f29170593cb371"

--- a/SOURCES/defs/2.7.1-railsexpress
+++ b/SOURCES/defs/2.7.1-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 08/Apr/2020 00:57:35 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.7.1-p0.7z" "9dc0a16d3a5d8f4bf7225e5d8b1c09a0801eb639"
   package: "ruby-2.7.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz" "76e25fce50a87f76a3ccd6d0fdd9b7c792400249"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.7.1-p0.7z" "9dc0a16d3a5d8f4bf7225e5d8b1c09a0801eb639"
   package: "ruby-2.7.1-p0" "https://ruby.kaos.st/ruby-2.7.1.7z" "93e71b984173ed85bf8e3fa012f29170593cb371"

--- a/SOURCES/defs/2.7.2
+++ b/SOURCES/defs/2.7.2
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:10:29 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.7.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz" "cb9731a17487e0ad84037490a6baf8bfa31a09e8"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.7.2-p0" "https://ruby.kaos.st/ruby-2.7.2.7z" "3285ff509ce2a9825f9fbcd67b652cb894a5f2e8"

--- a/SOURCES/defs/2.7.2
+++ b/SOURCES/defs/2.7.2
@@ -1,0 +1,19 @@
+# RBBuild Def File
+# UPDATED 29/Jan/2021 10:30:04 by Gleb Goncharov <g.goncharov@fun-box.ru>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+deps(bin): ruby
+
+CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1f): -j 1
+PREFIX(openssl-1.1.1f): {prefix}/openssl
+
+CONFOPTS(ruby-2.7.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "ruby-2.7.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz" "cb9731a17487e0ad84037490a6baf8bfa31a09e8"

--- a/SOURCES/defs/2.7.2-jemalloc
+++ b/SOURCES/defs/2.7.2-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:10:29 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.2-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   package: "ruby-2.7.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz" "cb9731a17487e0ad84037490a6baf8bfa31a09e8"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   package: "ruby-2.7.2-p0" "https://ruby.kaos.st/ruby-2.7.2.7z" "3285ff509ce2a9825f9fbcd67b652cb894a5f2e8"

--- a/SOURCES/defs/2.7.2-jemalloc
+++ b/SOURCES/defs/2.7.2-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 29/Jan/2021 10:30:04 by Gleb Goncharov <g.goncharov@fun-box.ru>
+# UPDATED 06/Feb/2021 01:10:29 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
@@ -15,3 +15,7 @@ CONFOPTS(ruby-2.7.2-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --d
 [default]
   package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
   package: "ruby-2.7.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz" "cb9731a17487e0ad84037490a6baf8bfa31a09e8"
+
+[essentialkaos]
+  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "ruby-2.7.2-p0" "https://ruby.kaos.st/ruby-2.7.2.7z" "3285ff509ce2a9825f9fbcd67b652cb894a5f2e8"

--- a/SOURCES/defs/2.7.2-jemalloc
+++ b/SOURCES/defs/2.7.2-jemalloc
@@ -1,0 +1,17 @@
+# RBBuild Def File
+# UPDATED 29/Jan/2021 10:30:04 by Gleb Goncharov <g.goncharov@fun-box.ru>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
+
+deps(bin): ruby
+
+CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1f): -j 1
+PREFIX(openssl-1.1.1f): {prefix}/openssl
+
+CONFOPTS(ruby-2.7.2-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "ruby-2.7.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz" "cb9731a17487e0ad84037490a6baf8bfa31a09e8"

--- a/SOURCES/defs/2.7.2-railsexpress
+++ b/SOURCES/defs/2.7.2-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:10:29 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1f): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1f): -j 1
-PREFIX(openssl-1.1.1f): {prefix}/openssl
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
   patchset: "https://ruby.kaos.st/patches/2.7.2-p0.7z" "40c604f6a92409828cc944371274d6555e72e7a6"
   package: "ruby-2.7.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz" "cb9731a17487e0ad84037490a6baf8bfa31a09e8"
 
 [essentialkaos]
-  package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
   patchset: "https://ruby.kaos.st/patches/2.7.2-p0.7z" "40c604f6a92409828cc944371274d6555e72e7a6"
   package: "ruby-2.7.2-p0" "https://ruby.kaos.st/ruby-2.7.2.7z" "3285ff509ce2a9825f9fbcd67b652cb894a5f2e8"

--- a/SOURCES/defs/2.7.2-railsexpress
+++ b/SOURCES/defs/2.7.2-railsexpress
@@ -16,8 +16,10 @@ CONFOPTS(ruby-2.7.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-d
 
 [default]
   package: "openssl-1.1.1f" "https://www.openssl.org/source/openssl-1.1.1f.tar.gz" "238e001ea1fbf19ede43e36209c37c1a636bb51f" openssl
+  patchset: "https://ruby.kaos.st/patches/2.7.2-p0.7z" "40c604f6a92409828cc944371274d6555e72e7a6"
   package: "ruby-2.7.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz" "cb9731a17487e0ad84037490a6baf8bfa31a09e8"
 
 [essentialkaos]
   package: "openssl-1.1.1f" "https://ruby.kaos.st/openssl-1.1.1f.7z" "f6c558eba43c138b9971482e3a4b469bba074489" openssl
+  patchset: "https://ruby.kaos.st/patches/2.7.2-p0.7z" "40c604f6a92409828cc944371274d6555e72e7a6"
   package: "ruby-2.7.2-p0" "https://ruby.kaos.st/ruby-2.7.2.7z" "3285ff509ce2a9825f9fbcd67b652cb894a5f2e8"

--- a/SOURCES/defs/3.0.0
+++ b/SOURCES/defs/3.0.0
@@ -1,0 +1,23 @@
+# RBBuild Def File
+# UPDATED 06/Feb/2021 01:42:04 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+deps(bin): ruby
+
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
+
+CONFOPTS(ruby-3.0.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "ruby-3.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz" "233873708c1ce9fdc295e0ef1c25e64f9b98b062"
+
+[essentialkaos]
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "ruby-3.0.0-p0" "https://ruby.kaos.st/ruby-3.0.0.7z" "b591fcbbfd661c2d0a1c17afa8fa2c4aabb76b10"

--- a/SOURCES/defs/3.0.0-jemalloc
+++ b/SOURCES/defs/3.0.0-jemalloc
@@ -1,0 +1,21 @@
+# RBBuild Def File
+# UPDATED 06/Feb/2021 01:42:04 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
+
+deps(bin): ruby
+
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
+
+CONFOPTS(ruby-3.0.0-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "ruby-3.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz" "233873708c1ce9fdc295e0ef1c25e64f9b98b062"
+
+[essentialkaos]
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "ruby-3.0.0-p0" "https://ruby.kaos.st/ruby-3.0.0.7z" "b591fcbbfd661c2d0a1c17afa8fa2c4aabb76b10"

--- a/SOURCES/defs/3.0.0-railsexpress
+++ b/SOURCES/defs/3.0.0-railsexpress
@@ -1,0 +1,25 @@
+# RBBuild Def File
+# UPDATED 06/Feb/2021 01:42:04 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
+deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
+
+deps(bin): ruby
+
+CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1i): -j 1
+PREFIX(openssl-1.1.1i): {prefix}/openssl
+
+CONFOPTS(ruby-3.0.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  patchset: "https://ruby.kaos.st/patches/3.0.0-p0.7z" "26795be7d0e445b06c85b1c3635ace6fb96831c2"
+  package: "ruby-3.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz" "233873708c1ce9fdc295e0ef1c25e64f9b98b062"
+
+[essentialkaos]
+  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  patchset: "https://ruby.kaos.st/patches/3.0.0-p0.7z" "26795be7d0e445b06c85b1c3635ace6fb96831c2"
+  package: "ruby-3.0.0-p0" "https://ruby.kaos.st/ruby-3.0.0.7z" "b591fcbbfd661c2d0a1c17afa8fa2c4aabb76b10"

--- a/SOURCES/defs/jruby-9.0.0.0
+++ b/SOURCES/defs/jruby-9.0.0.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2016-05-03
+eol(security): 2016-05-03
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.0.1.0
+++ b/SOURCES/defs/jruby-9.0.1.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2016-05-03
+eol(security): 2016-05-03
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.0.3.0
+++ b/SOURCES/defs/jruby-9.0.3.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2016-05-03
+eol(security): 2016-05-03
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.0.4.0
+++ b/SOURCES/defs/jruby-9.0.4.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2016-05-03
+eol(security): 2016-05-03
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.0.5.0
+++ b/SOURCES/defs/jruby-9.0.5.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2016-05-03
+eol(security): 2016-05-03
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.0.0
+++ b/SOURCES/defs/jruby-9.1.0.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.1.0
+++ b/SOURCES/defs/jruby-9.1.1.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.10.0
+++ b/SOURCES/defs/jruby-9.1.10.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.11.0
+++ b/SOURCES/defs/jruby-9.1.11.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.12.0
+++ b/SOURCES/defs/jruby-9.1.12.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.13.0
+++ b/SOURCES/defs/jruby-9.1.13.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.14.0
+++ b/SOURCES/defs/jruby-9.1.14.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.15.0
+++ b/SOURCES/defs/jruby-9.1.15.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.16.0
+++ b/SOURCES/defs/jruby-9.1.16.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.17.0
+++ b/SOURCES/defs/jruby-9.1.17.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.2.0
+++ b/SOURCES/defs/jruby-9.1.2.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.3.0
+++ b/SOURCES/defs/jruby-9.1.3.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.4.0
+++ b/SOURCES/defs/jruby-9.1.4.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.5.0
+++ b/SOURCES/defs/jruby-9.1.5.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.6.0
+++ b/SOURCES/defs/jruby-9.1.6.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.7.0
+++ b/SOURCES/defs/jruby-9.1.7.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.8.0
+++ b/SOURCES/defs/jruby-9.1.8.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.1.9.0
+++ b/SOURCES/defs/jruby-9.1.9.0
@@ -1,6 +1,9 @@
 # RBBuild Def File
 # UPDATED 18/Oct/2018 12:16:20 by Anton Novojilov <andy@essentialkaos.com>
 
+eol(normal): 2018-05-24
+eol(security): 2018-05-24
+
 deps(rpm): make gcc gcc-c++
 deps(deb): make gcc build-essentials
 deps(bin): java

--- a/SOURCES/defs/jruby-9.2.12.0
+++ b/SOURCES/defs/jruby-9.2.12.0
@@ -1,0 +1,12 @@
+# RBBuild Def File
+# UPDATED 06/Feb/2021 01:15:33 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): make gcc gcc-c++
+deps(deb): make gcc build-essentials
+deps(bin): java
+
+[default]
+  package: "jruby-9.2.12.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.12.0/jruby-bin-9.2.12.0.tar.gz" "bccc2034e773cb1aba2cc4b8b40921265f6e857f" jruby
+
+[essentialkaos]
+  package: "jruby-9.2.12.0" "https://ruby.kaos.st/jruby-9.2.12.0.7z" "fbf88f98c9f8f30484785c8166abf2e747d7652d" jruby

--- a/SOURCES/defs/jruby-9.2.13.0
+++ b/SOURCES/defs/jruby-9.2.13.0
@@ -1,0 +1,12 @@
+# RBBuild Def File
+# UPDATED 06/Feb/2021 01:15:33 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): make gcc gcc-c++
+deps(deb): make gcc build-essentials
+deps(bin): java
+
+[default]
+  package: "jruby-9.2.13.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.13.0/jruby-bin-9.2.13.0.tar.gz" "876bee4475c1d22b1acd437fcdf7f38b682f0e60" jruby
+
+[essentialkaos]
+  package: "jruby-9.2.13.0" "https://ruby.kaos.st/jruby-9.2.13.0.7z" "5e238d6f85a9a05ff3e17830a1828c789f128468" jruby

--- a/SOURCES/defs/jruby-9.2.14.0
+++ b/SOURCES/defs/jruby-9.2.14.0
@@ -1,0 +1,12 @@
+# RBBuild Def File
+# UPDATED 06/Feb/2021 01:15:33 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): make gcc gcc-c++
+deps(deb): make gcc build-essentials
+deps(bin): java
+
+[default]
+  package: "jruby-9.2.14.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.14.0/jruby-bin-9.2.14.0.tar.gz" "7946d572d3c04cf4457566b9a58688410e468da5" jruby
+
+[essentialkaos]
+  package: "jruby-9.2.14.0" "https://ruby.kaos.st/jruby-9.2.14.0.7z" "df465204940b972caa29606d48b31773391e4ca5" jruby

--- a/SOURCES/defs/truffleruby-20.2.0
+++ b/SOURCES/defs/truffleruby-20.2.0
@@ -1,0 +1,11 @@
+# RBBuild Def File
+# UPDATED 06/Feb/2021 17:30:58 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): gcc openssl-devel
+deps(deb): gcc libssl-dev
+
+[default]
+  package: "truffleruby-20.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-20.2.0/truffleruby-20.2.0-linux-amd64.tar.gz" "2215c1bca88a46ee8047e419c47cb45f7b753150" truffle
+
+[essentialkaos]
+  package: "truffleruby-20.2.0" "https://ruby.kaos.st/truffleruby-20.2.0.7z" "23b8242155b565d611b0c8c2d7c1a7fb777be76f" truffle

--- a/SOURCES/defs/truffleruby-20.3.0
+++ b/SOURCES/defs/truffleruby-20.3.0
@@ -1,0 +1,11 @@
+# RBBuild Def File
+# UPDATED 06/Feb/2021 17:30:58 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): gcc openssl-devel
+deps(deb): gcc libssl-dev
+
+[default]
+  package: "truffleruby-20.3.0" "https://github.com/oracle/truffleruby/releases/download/vm-20.3.0/truffleruby-20.3.0-linux-amd64.tar.gz" "37e1abfeb680874d017789cb41dbb49e81f4ebac" truffle
+
+[essentialkaos]
+  package: "truffleruby-20.3.0" "https://ruby.kaos.st/truffleruby-20.3.0.7z" "dd4b76e2e11495d242402dfb15be8efc9cf67127" truffle

--- a/SOURCES/defs/truffleruby-21.0.0
+++ b/SOURCES/defs/truffleruby-21.0.0
@@ -1,0 +1,11 @@
+# RBBuild Def File
+# UPDATED 06/Feb/2021 17:30:58 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): gcc openssl-devel
+deps(deb): gcc libssl-dev
+
+[default]
+  package: "truffleruby-21.0.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.0.0/truffleruby-21.0.0-linux-amd64.tar.gz" "5a7dcfc600f615d37a90881d467145459bb4ff2d" truffle
+
+[essentialkaos]
+  package: "truffleruby-21.0.0" "https://ruby.kaos.st/truffleruby-21.0.0.7z" "c0afdbf42f9da38881788ff34d1353c8f9e1f26b" truffle

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -91,6 +91,7 @@ rm -rf %{buildroot}
 - Added truffleruby-21.0.0
 - OpenSSL updated to 1.0.2u for 1.9.2 <-> 2.3.8
 - OpenSSL updated to 1.1.1f for 2.4.0 <-> 2.7.1
+- Added EOL dates for 2.3.x, 2.4.x, 2.5.x, jruby-9.0.x.x and jruby-9.1.x.x
 
 * Fri Jun 19 2020 Anton Novojilov <andy@essentialkaos.com> - 1.10.1-0
 - Added truffleruby-19.3.0

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -83,9 +83,12 @@ rm -rf %{buildroot}
 - Added 3.0.0-p0
 - Added 3.0.0-p0-jemalloc
 - Added 3.0.0-p0-railsexpress
-- Fixed jruby-9.2.12.0
-- Fixed jruby-9.2.13.0
-- Fixed jruby-9.2.14.0
+- Added jruby-9.2.12.0
+- Added jruby-9.2.13.0
+- Added jruby-9.2.14.0
+- Added truffleruby-20.2.0
+- Added truffleruby-20.3.0
+- Added truffleruby-21.0.0
 - OpenSSL updated to 1.0.2u for 1.9.2 <-> 2.3.8
 - OpenSSL updated to 1.1.1f for 2.4.0 <-> 2.7.1
 

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -29,7 +29,7 @@
 
 Summary:         Def files for rbbuild utility
 Name:            rbbuild-defs
-Version:         1.10.1
+Version:         1.10.2
 Release:         0%{?dist}
 License:         Apache License, Version 2.0
 Vendor:          ESSENTIALKAOS
@@ -76,6 +76,19 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Sat Feb 06 2021 Anton Novojilov <andy@essentialkaos.com> - 1.10.2-0
+- Added 2.7.2-p0
+- Added 2.7.2-p0-jemalloc
+- Added 2.7.2-p0-railsexpress
+- Added 3.0.0-p0
+- Added 3.0.0-p0-jemalloc
+- Added 3.0.0-p0-railsexpress
+- Fixed jruby-9.2.12.0
+- Fixed jruby-9.2.13.0
+- Fixed jruby-9.2.14.0
+- OpenSSL updated to 1.0.2u for 1.9.2 <-> 2.3.8
+- OpenSSL updated to 1.1.1f for 2.4.0 <-> 2.7.1
+
 * Fri Jun 19 2020 Anton Novojilov <andy@essentialkaos.com> - 1.10.1-0
 - Added truffleruby-19.3.0
 - Added truffleruby-19.3.0.2


### PR DESCRIPTION
### New
- Added `2.7.2-p0` by @gongled 
- Added `2.7.2-p0-jemalloc` by @gongled 
- Added `2.7.2-p0-railsexpress`
- Added `3.0.0-p0`
- Added `3.0.0-p0-jemalloc`
- Added `3.0.0-p0-railsexpress`
- Added `jruby-9.2.12.0`
- Added `jruby-9.2.13.0`
- Added `jruby-9.2.14.0`
- Added `truffleruby-20.2.0`
- Added `truffleruby-20.3.0`
- Added `truffleruby-21.0.0`

### Improvements
- OpenSSL updated to `1.0.2u` for `1.9.2` - `2.3.8`
- OpenSSL updated to `1.1.1f` for `2.4.0` - `2.7.1`
- Added EOL dates for `2.3.x`, `2.4.x`, `2.5.x`, `jruby-9.0.x.x` and `jruby-9.1.x.x`