### PR TITLE
Version 1.10.3

### DIFF
--- a/SOURCES/rbbuild
+++ b/SOURCES/rbbuild
@@ -13,7 +13,7 @@ fi
 APP="RBBuild"
 
 # App version (String)
-VER="1.10.2"
+VER="1.10.3"
 
 ################################################################################
 
@@ -1232,9 +1232,17 @@ fetchRemoteFile() {
   file_name="$2"
 
   if [[ -n "$dl_cache" ]] ; then
-    cache_dir="$CWD/$dl_cache"
+    cache_dir="$dl_cache"
 
-    [[ ! -d "$cache_dir" ]] && mkdir -p "$cache_dir"
+    if [[ ! -d "$cache_dir" ]] ; then
+      if ! mkdir -p "$cache_dir" &> /dev/null ; then
+        printErrorAndExit "Can't create directory $dl_cache for download cache"
+      fi
+    fi
+
+    if ! checkPerms "DRWX" "$cache_dir" ; then
+      printErrorAndExit "Can't user directory $dl_cache for download cache"
+    fi
 
     if [[ ! -f "$cache_dir/$file_name" ]] ; then
       pushd "$cache_dir" &> $verb_output || printErrorAndExit "Can't set working dir to $cache_dir"

--- a/SOURCES/rbbuild
+++ b/SOURCES/rbbuild
@@ -1953,6 +1953,10 @@ download() {
     curl $opts -# "$1" -o "$2"
   fi
 
+  if [[ -f "$2" ]] ; then
+    chmod 600 "$2"
+  fi
+
   return $?
 }
 

--- a/rbbuild.spec
+++ b/rbbuild.spec
@@ -78,8 +78,7 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%doc LICENSE.EN
-%doc LICENSE.RU
+%doc LICENSE
 %{_bindir}/rbbuild
 %{_bindir}/rbdef
 %{blds_dir}

--- a/rbbuild.spec
+++ b/rbbuild.spec
@@ -29,7 +29,7 @@
 
 Summary:         Utility for compiling and installing different ruby versions
 Name:            rbbuild
-Version:         1.10.2
+Version:         1.10.3
 Release:         0%{?dist}
 License:         Apache License, Version 2.0
 Vendor:          ESSENTIALKAOS
@@ -87,6 +87,10 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Mon Feb 08 2021 Anton Novojilov <andy@essentialkaos.com> - 1.10.3-0
+- Do not use current working directory for download cache
+- Use 0600 as default mode for all files in download cache
+
 * Tue Jun 30 2020 Anton Novojilov <andy@essentialkaos.com> - 1.10.2-0
 - Added check for noexec flag for temporary directory
 


### PR DESCRIPTION
#### Improvements
* `RBB-2` Do not use current working directory for download cache
* `RBB-3` Use `0600` as default mode for all files in download cache
