### PR TITLE
Defs Update

### DIFF
--- a/SOURCES/defs/2.4.0
+++ b/SOURCES/defs/2.4.0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:11 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.gz" "d44a3c50a0e742341ed3033d5db79d865151a4f4"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.0-p0" "https://ruby.kaos.st/ruby-2.4.0.7z" "04ea478c6645fc46506ec000f514deaed91d98e3"

--- a/SOURCES/defs/2.4.0-jemalloc
+++ b/SOURCES/defs/2.4.0-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:11 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -7,16 +7,16 @@ eol(security): 2020-03-31
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.0-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.gz" "d44a3c50a0e742341ed3033d5db79d865151a4f4"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.0-p0" "https://ruby.kaos.st/ruby-2.4.0.7z" "04ea478c6645fc46506ec000f514deaed91d98e3"

--- a/SOURCES/defs/2.4.0-railsexpress
+++ b/SOURCES/defs/2.4.0-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:11 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.0-p0.7z" "c1317a0ad3e0eddf51782d44825fb1ebbef1610f"
   package: "ruby-2.4.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.gz" "d44a3c50a0e742341ed3033d5db79d865151a4f4"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.0-p0.7z" "c1317a0ad3e0eddf51782d44825fb1ebbef1610f"
   package: "ruby-2.4.0-p0" "https://ruby.kaos.st/ruby-2.4.0.7z" "04ea478c6645fc46506ec000f514deaed91d98e3"

--- a/SOURCES/defs/2.4.1
+++ b/SOURCES/defs/2.4.1
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.gz" "47909a0f77ea900573f027d27746960ad6d07d15"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.1-p0" "https://ruby.kaos.st/ruby-2.4.1.7z" "945e24c959c6a803d27448a7ee452119592dd132"

--- a/SOURCES/defs/2.4.1-jemalloc
+++ b/SOURCES/defs/2.4.1-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -7,16 +7,16 @@ eol(security): 2020-03-31
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.1-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.gz" "47909a0f77ea900573f027d27746960ad6d07d15"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.1-p0" "https://ruby.kaos.st/ruby-2.4.1.7z" "945e24c959c6a803d27448a7ee452119592dd132"

--- a/SOURCES/defs/2.4.1-railsexpress
+++ b/SOURCES/defs/2.4.1-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:43 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.1-p0.7z" "23adaf9d672104319439eda723072ad1beba3d76"
   package: "ruby-2.4.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.gz" "47909a0f77ea900573f027d27746960ad6d07d15"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.1-p0.7z" "23adaf9d672104319439eda723072ad1beba3d76"
   package: "ruby-2.4.1-p0" "https://ruby.kaos.st/ruby-2.4.1.7z" "945e24c959c6a803d27448a7ee452119592dd132"

--- a/SOURCES/defs/2.4.2
+++ b/SOURCES/defs/2.4.2
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz" "b096124469e31e4fc3d00d2b61b11d36992e6bbd"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.2-p0" "https://ruby.kaos.st/ruby-2.4.2.7z" "eeaca7e29fb059dec33e1bb41c25eec80f577266"

--- a/SOURCES/defs/2.4.2-jemalloc
+++ b/SOURCES/defs/2.4.2-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -7,16 +7,16 @@ eol(security): 2020-03-31
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.2-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz" "b096124469e31e4fc3d00d2b61b11d36992e6bbd"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.2-p0" "https://ruby.kaos.st/ruby-2.4.2.7z" "eeaca7e29fb059dec33e1bb41c25eec80f577266"

--- a/SOURCES/defs/2.4.2-railsexpress
+++ b/SOURCES/defs/2.4.2-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc git make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.2-p0.7z" "9753df86aaa42e5f0262fbd7ea6449bed8f2a29a"
   package: "ruby-2.4.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz" "b096124469e31e4fc3d00d2b61b11d36992e6bbd"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.2-p0.7z" "9753df86aaa42e5f0262fbd7ea6449bed8f2a29a"
   package: "ruby-2.4.2-p0" "https://ruby.kaos.st/ruby-2.4.2.7z" "eeaca7e29fb059dec33e1bb41c25eec80f577266"

--- a/SOURCES/defs/2.4.3
+++ b/SOURCES/defs/2.4.3
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.gz" "787b7f4e90fb4b39a61bc1a31eb7765f875a590c"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.3-p0" "https://ruby.kaos.st/ruby-2.4.3.7z" "1cd2dfe3c7e4329d37935ff875419d6cebbd7170"

--- a/SOURCES/defs/2.4.3-jemalloc
+++ b/SOURCES/defs/2.4.3-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -7,16 +7,16 @@ eol(security): 2020-03-31
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.3-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.gz" "787b7f4e90fb4b39a61bc1a31eb7765f875a590c"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.3-p0" "https://ruby.kaos.st/ruby-2.4.3.7z" "1cd2dfe3c7e4329d37935ff875419d6cebbd7170"

--- a/SOURCES/defs/2.4.3-railsexpress
+++ b/SOURCES/defs/2.4.3-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.3-p0.7z" "82a23b845ece89ac05cc36008a9de22dea6a0f2d"
   package: "ruby-2.4.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.gz" "787b7f4e90fb4b39a61bc1a31eb7765f875a590c"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.3-p0.7z" "82a23b845ece89ac05cc36008a9de22dea6a0f2d"
   package: "ruby-2.4.3-p0" "https://ruby.kaos.st/ruby-2.4.3.7z" "1cd2dfe3c7e4329d37935ff875419d6cebbd7170"

--- a/SOURCES/defs/2.4.4
+++ b/SOURCES/defs/2.4.4
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.gz" "ec82b0d53bd0adad9b19e6b45e44d54e9ec3f10c"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.4-p0" "https://ruby.kaos.st/ruby-2.4.4.7z" "ca54892a46ad75e18596930ebf682214ce0db886"

--- a/SOURCES/defs/2.4.4-jemalloc
+++ b/SOURCES/defs/2.4.4-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -7,16 +7,16 @@ eol(security): 2020-03-31
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.4-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.gz" "ec82b0d53bd0adad9b19e6b45e44d54e9ec3f10c"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.4-p0" "https://ruby.kaos.st/ruby-2.4.4.7z" "ca54892a46ad75e18596930ebf682214ce0db886"

--- a/SOURCES/defs/2.4.4-railsexpress
+++ b/SOURCES/defs/2.4.4-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.4-p0.7z" "0e8793d77ea95826982763737779cfed1ac5d2e9"
   package: "ruby-2.4.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.gz" "ec82b0d53bd0adad9b19e6b45e44d54e9ec3f10c"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.4-p0.7z" "0e8793d77ea95826982763737779cfed1ac5d2e9"
   package: "ruby-2.4.4-p0" "https://ruby.kaos.st/ruby-2.4.4.7z" "ca54892a46ad75e18596930ebf682214ce0db886"

--- a/SOURCES/defs/2.4.5
+++ b/SOURCES/defs/2.4.5
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.gz" "4d650f302f1ec00256450b112bb023644b6ab6dd"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.5-p0" "https://ruby.kaos.st/ruby-2.4.5.7z" "5b84b9806c2e651582ee8033c3d0e9c148c11d9b"

--- a/SOURCES/defs/2.4.5-jemalloc
+++ b/SOURCES/defs/2.4.5-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -7,16 +7,16 @@ eol(security): 2020-03-31
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.5-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.gz" "4d650f302f1ec00256450b112bb023644b6ab6dd"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.5-p0" "https://ruby.kaos.st/ruby-2.4.5.7z" "5b84b9806c2e651582ee8033c3d0e9c148c11d9b"

--- a/SOURCES/defs/2.4.5-railsexpress
+++ b/SOURCES/defs/2.4.5-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.5-p0.7z" "ac9eea5118f483bc278ace43119e4a2b12a73670"
   package: "ruby-2.4.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.gz" "4d650f302f1ec00256450b112bb023644b6ab6dd"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.5-p0.7z" "ac9eea5118f483bc278ace43119e4a2b12a73670"
   package: "ruby-2.4.5-p0" "https://ruby.kaos.st/ruby-2.4.5.7z" "5b84b9806c2e651582ee8033c3d0e9c148c11d9b"

--- a/SOURCES/defs/2.4.6
+++ b/SOURCES/defs/2.4.6
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.gz" "3bc2d9ab3381887c57e0fb7937dc14e9f419f06c"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.6-p0" "https://ruby.kaos.st/ruby-2.4.6.7z" "68f9fbc4de6e9681452832febcd72ee6c27d69f4"

--- a/SOURCES/defs/2.4.6-jemalloc
+++ b/SOURCES/defs/2.4.6-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -7,16 +7,16 @@ eol(security): 2020-03-31
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.6-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.gz" "3bc2d9ab3381887c57e0fb7937dc14e9f419f06c"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.6-p0" "https://ruby.kaos.st/ruby-2.4.6.7z" "68f9fbc4de6e9681452832febcd72ee6c27d69f4"

--- a/SOURCES/defs/2.4.6-railsexpress
+++ b/SOURCES/defs/2.4.6-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.6-p0.7z" "bfa5d520a9aae7b10add7e7d5d1187971db34bd5"
   package: "ruby-2.4.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.gz" "3bc2d9ab3381887c57e0fb7937dc14e9f419f06c"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.6-p0.7z" "bfa5d520a9aae7b10add7e7d5d1187971db34bd5"
   package: "ruby-2.4.6-p0" "https://ruby.kaos.st/ruby-2.4.6.7z" "68f9fbc4de6e9681452832febcd72ee6c27d69f4"

--- a/SOURCES/defs/2.4.7
+++ b/SOURCES/defs/2.4.7
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz" "607384450348bd87028cd8d1ebf09f21103d0cd2"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.7-p0" "https://ruby.kaos.st/ruby-2.4.7.7z" "2a8d8fcc4cb62f6f30246b38d9999764a6332f96"

--- a/SOURCES/defs/2.4.7-jemalloc
+++ b/SOURCES/defs/2.4.7-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:12 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -7,16 +7,16 @@ eol(security): 2020-03-31
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.7-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz" "607384450348bd87028cd8d1ebf09f21103d0cd2"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.7-p0" "https://ruby.kaos.st/ruby-2.4.7.7z" "2a8d8fcc4cb62f6f30246b38d9999764a6332f96"

--- a/SOURCES/defs/2.4.9
+++ b/SOURCES/defs/2.4.9
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.9-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.9-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.gz" "da07b802cf7598547f98b7b2d8fc8ff5f03dbef4"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.9-p0" "https://ruby.kaos.st/ruby-2.4.9.7z" "4112c40582b482e8812f349edd415d0427b5db9c"

--- a/SOURCES/defs/2.4.9-jemalloc
+++ b/SOURCES/defs/2.4.9-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -7,16 +7,16 @@ eol(security): 2020-03-31
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.9-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.4.9-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.gz" "da07b802cf7598547f98b7b2d8fc8ff5f03dbef4"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.4.9-p0" "https://ruby.kaos.st/ruby-2.4.9.7z" "4112c40582b482e8812f349edd415d0427b5db9c"

--- a/SOURCES/defs/2.4.9-railsexpress
+++ b/SOURCES/defs/2.4.9-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:44 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2019-03-31
 eol(security): 2020-03-31
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): gcc make zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.4.9-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.9-p0.7z" "79fee10ec597308c97804fe5653c8a7f479bc54c"
   package: "ruby-2.4.9-p0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.gz" "da07b802cf7598547f98b7b2d8fc8ff5f03dbef4"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.4.9-p0.7z" "79fee10ec597308c97804fe5653c8a7f479bc54c"
   package: "ruby-2.4.9-p0" "https://ruby.kaos.st/ruby-2.4.9.7z" "4112c40582b482e8812f349edd415d0427b5db9c"

--- a/SOURCES/defs/2.5.0
+++ b/SOURCES/defs/2.5.0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,18 +11,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.0-p0): --with-openssl-dir={prefix}/openssl --with-baseruby={ruby_bin} --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patch: "https://github.com/ruby/ruby/commit/de11e472b447df6d45cd2eaa577d0f2f1efd4064.patch" "4bd7b9e2893f56b6833a16be52f64193b6c02ed1"
   package: "ruby-2.5.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.gz" "58f77301c891c1c4a08f301861c26b1ea46509f6"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patch: "https://github.com/ruby/ruby/commit/de11e472b447df6d45cd2eaa577d0f2f1efd4064.patch" "4bd7b9e2893f56b6833a16be52f64193b6c02ed1"
   package: "ruby-2.5.0-p0" "https://ruby.kaos.st/ruby-2.5.0.7z" "018048c1ceb894762631393427ffcf354db40af7"

--- a/SOURCES/defs/2.5.0-jemalloc
+++ b/SOURCES/defs/2.5.0-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -9,18 +9,18 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.0-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --with-baseruby={ruby_bin} --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patch: "https://github.com/ruby/ruby/commit/de11e472b447df6d45cd2eaa577d0f2f1efd4064.patch" "4bd7b9e2893f56b6833a16be52f64193b6c02ed1"
   package: "ruby-2.5.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.gz" "58f77301c891c1c4a08f301861c26b1ea46509f6"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patch: "https://github.com/ruby/ruby/commit/de11e472b447df6d45cd2eaa577d0f2f1efd4064.patch" "4bd7b9e2893f56b6833a16be52f64193b6c02ed1"
   package: "ruby-2.5.0-p0" "https://ruby.kaos.st/ruby-2.5.0.7z" "018048c1ceb894762631393427ffcf354db40af7"

--- a/SOURCES/defs/2.5.0-railsexpress
+++ b/SOURCES/defs/2.5.0-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,20 +11,20 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.0-p0): --with-openssl-dir={prefix}/openssl --with-baseruby={ruby_bin} --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patch: "https://github.com/ruby/ruby/commit/de11e472b447df6d45cd2eaa577d0f2f1efd4064.patch" "4bd7b9e2893f56b6833a16be52f64193b6c02ed1"
   patchset: "https://ruby.kaos.st/patches/2.5.0-p0.7z" "52388c989f89b77b98d2cfdf374ac5e6f596dfb0"
   package: "ruby-2.5.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.gz" "58f77301c891c1c4a08f301861c26b1ea46509f6"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patch: "https://github.com/ruby/ruby/commit/de11e472b447df6d45cd2eaa577d0f2f1efd4064.patch" "4bd7b9e2893f56b6833a16be52f64193b6c02ed1"
   patchset: "https://ruby.kaos.st/patches/2.5.0-p0.7z" "52388c989f89b77b98d2cfdf374ac5e6f596dfb0"
   package: "ruby-2.5.0-p0" "https://ruby.kaos.st/ruby-2.5.0.7z" "018048c1ceb894762631393427ffcf354db40af7"

--- a/SOURCES/defs/2.5.1
+++ b/SOURCES/defs/2.5.1
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,16 +11,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.gz" "93fafd57a724974b951957c522cdc4478a6bdc2e"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.1-p0" "https://ruby.kaos.st/ruby-2.5.1.7z" "324911ba95363737825c0c748da6552d7a33f114"

--- a/SOURCES/defs/2.5.1-jemalloc
+++ b/SOURCES/defs/2.5.1-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.1-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.gz" "93fafd57a724974b951957c522cdc4478a6bdc2e"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.1-p0" "https://ruby.kaos.st/ruby-2.5.1.7z" "324911ba95363737825c0c748da6552d7a33f114"

--- a/SOURCES/defs/2.5.1-railsexpress
+++ b/SOURCES/defs/2.5.1-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,18 +11,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.1-p0.7z" "e77a8d22b508e0c260f234233ccb2f980188be8b"
   package: "ruby-2.5.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.gz" "93fafd57a724974b951957c522cdc4478a6bdc2e"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.1-p0.7z" "e77a8d22b508e0c260f234233ccb2f980188be8b"
   package: "ruby-2.5.1-p0" "https://ruby.kaos.st/ruby-2.5.1.7z" "324911ba95363737825c0c748da6552d7a33f114"

--- a/SOURCES/defs/2.5.2
+++ b/SOURCES/defs/2.5.2
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,16 +11,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.2.tar.gz" "7e503e75621b69cedb1d8b3fa2bee5aef2f1a714"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.2-p0" "https://ruby.kaos.st/ruby-2.5.2.7z" "4a8c45bdcf33b481970610d19f796fa835d30f4f"

--- a/SOURCES/defs/2.5.2-jemalloc
+++ b/SOURCES/defs/2.5.2-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.2-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.2.tar.gz" "7e503e75621b69cedb1d8b3fa2bee5aef2f1a714"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.2-p0" "https://ruby.kaos.st/ruby-2.5.2.7z" "4a8c45bdcf33b481970610d19f796fa835d30f4f"

--- a/SOURCES/defs/2.5.3
+++ b/SOURCES/defs/2.5.3
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,16 +11,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.gz" "f919a9fbcdb7abecd887157b49833663c5c15fda"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.3-p0" "https://ruby.kaos.st/ruby-2.5.3.7z" "8d95f53cc308a0e55ec90d75704e0a087b1eda0c"

--- a/SOURCES/defs/2.5.3-jemalloc
+++ b/SOURCES/defs/2.5.3-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.3-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.gz" "f919a9fbcdb7abecd887157b49833663c5c15fda"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.3-p0" "https://ruby.kaos.st/ruby-2.5.3.7z" "8d95f53cc308a0e55ec90d75704e0a087b1eda0c"

--- a/SOURCES/defs/2.5.3-railsexpress
+++ b/SOURCES/defs/2.5.3-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,18 +11,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.3-p0.7z" "c016845495ea8487e38a2509cdbcad7540d7e041"
   package: "ruby-2.5.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.gz" "f919a9fbcdb7abecd887157b49833663c5c15fda"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.3-p0.7z" "c016845495ea8487e38a2509cdbcad7540d7e041"
   package: "ruby-2.5.3-p0" "https://ruby.kaos.st/ruby-2.5.3.7z" "8d95f53cc308a0e55ec90d75704e0a087b1eda0c"

--- a/SOURCES/defs/2.5.4
+++ b/SOURCES/defs/2.5.4
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,16 +11,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.gz" "330bb5472f565b683c7f8c9091d4ee0cc155b51b"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.4-p0" "https://ruby.kaos.st/ruby-2.5.4.7z" "038286f2468ddc6f40bcb54e2b2199ef984289e5"

--- a/SOURCES/defs/2.5.4-jemalloc
+++ b/SOURCES/defs/2.5.4-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.4-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.gz" "330bb5472f565b683c7f8c9091d4ee0cc155b51b"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.4-p0" "https://ruby.kaos.st/ruby-2.5.4.7z" "038286f2468ddc6f40bcb54e2b2199ef984289e5"

--- a/SOURCES/defs/2.5.4-railsexpress
+++ b/SOURCES/defs/2.5.4-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,18 +11,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.4-p0.7z" "e6a917cca85d9b2554d44349d7cb505c33a9a44f"
   package: "ruby-2.5.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.gz" "330bb5472f565b683c7f8c9091d4ee0cc155b51b"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.4-p0.7z" "e6a917cca85d9b2554d44349d7cb505c33a9a44f"
   package: "ruby-2.5.4-p0" "https://ruby.kaos.st/ruby-2.5.4.7z" "038286f2468ddc6f40bcb54e2b2199ef984289e5"

--- a/SOURCES/defs/2.5.5
+++ b/SOURCES/defs/2.5.5
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,16 +11,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.gz" "e6a063728950762925108abbdbf68968ec1ab5bb"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.5-p0" "https://ruby.kaos.st/ruby-2.5.5.7z" "b107f4d615e43f60d6ebc33ae1621909fe3e708d"

--- a/SOURCES/defs/2.5.5-jemalloc
+++ b/SOURCES/defs/2.5.5-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.5-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.gz" "e6a063728950762925108abbdbf68968ec1ab5bb"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.5-p0" "https://ruby.kaos.st/ruby-2.5.5.7z" "b107f4d615e43f60d6ebc33ae1621909fe3e708d"

--- a/SOURCES/defs/2.5.5-railsexpress
+++ b/SOURCES/defs/2.5.5-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:13 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,18 +11,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.5-p0.7z" "32ff7f8c7cf47a72037c1e96e75023b88b55757b"
   package: "ruby-2.5.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.gz" "e6a063728950762925108abbdbf68968ec1ab5bb"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.5-p0.7z" "32ff7f8c7cf47a72037c1e96e75023b88b55757b"
   package: "ruby-2.5.5-p0" "https://ruby.kaos.st/ruby-2.5.5.7z" "b107f4d615e43f60d6ebc33ae1621909fe3e708d"

--- a/SOURCES/defs/2.5.6
+++ b/SOURCES/defs/2.5.6
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,16 +11,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz" "d2dd34da5f3b63a0075e50133f60eb35d71b7543"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.6-p0" "https://ruby.kaos.st/ruby-2.5.6.7z" "a31c2f1299e6a5b8790ebfecf84670313037063a"

--- a/SOURCES/defs/2.5.6-jemalloc
+++ b/SOURCES/defs/2.5.6-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:45 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.6-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz" "d2dd34da5f3b63a0075e50133f60eb35d71b7543"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.6-p0" "https://ruby.kaos.st/ruby-2.5.6.7z" "a31c2f1299e6a5b8790ebfecf84670313037063a"

--- a/SOURCES/defs/2.5.6-railsexpress
+++ b/SOURCES/defs/2.5.6-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,18 +11,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.6-p0.7z" "7484b0e2ba0987c66bf3b034f9f8c9615952e0bd"
   package: "ruby-2.5.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz" "d2dd34da5f3b63a0075e50133f60eb35d71b7543"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.6-p0.7z" "7484b0e2ba0987c66bf3b034f9f8c9615952e0bd"
   package: "ruby-2.5.6-p0" "https://ruby.kaos.st/ruby-2.5.6.7z" "a31c2f1299e6a5b8790ebfecf84670313037063a"

--- a/SOURCES/defs/2.5.7
+++ b/SOURCES/defs/2.5.7
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,16 +11,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.gz" "541039290d188fff683a1d2f2892bd74854dd022"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.7-p0" "https://ruby.kaos.st/ruby-2.5.7.7z" "0b4aa716b9e800cb333d9280e72b8f03fbdb5746"

--- a/SOURCES/defs/2.5.7-jemalloc
+++ b/SOURCES/defs/2.5.7-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.7-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.gz" "541039290d188fff683a1d2f2892bd74854dd022"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.7-p0" "https://ruby.kaos.st/ruby-2.5.7.7z" "0b4aa716b9e800cb333d9280e72b8f03fbdb5746"

--- a/SOURCES/defs/2.5.7-railsexpress
+++ b/SOURCES/defs/2.5.7-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,18 +11,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.7-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.7-p0.7z" "b75fa2333435a786909ef9d48598d2b9e663f9d9"
   package: "ruby-2.5.7-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.gz" "541039290d188fff683a1d2f2892bd74854dd022"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.7-p0.7z" "b75fa2333435a786909ef9d48598d2b9e663f9d9"
   package: "ruby-2.5.7-p0" "https://ruby.kaos.st/ruby-2.5.7.7z" "0b4aa716b9e800cb333d9280e72b8f03fbdb5746"

--- a/SOURCES/defs/2.5.8
+++ b/SOURCES/defs/2.5.8
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,16 +11,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.8-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.8-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.gz" "71e7b22d1dfa32d3df0bfeec48237b28a53bc04f"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.8-p0" "https://ruby.kaos.st/ruby-2.5.8.7z" "17df6dc748a4e94be31f469dbede4bfeceb13994"

--- a/SOURCES/defs/2.5.8-jemalloc
+++ b/SOURCES/defs/2.5.8-jemalloc
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -9,16 +9,16 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.8-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.5.8-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.gz" "71e7b22d1dfa32d3df0bfeec48237b28a53bc04f"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.5.8-p0" "https://ruby.kaos.st/ruby-2.5.8.7z" "17df6dc748a4e94be31f469dbede4bfeceb13994"

--- a/SOURCES/defs/2.5.8-railsexpress
+++ b/SOURCES/defs/2.5.8-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2020-03-31
 eol(security): 2021-03-31
@@ -11,18 +11,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.5.8-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.8-p0.7z" "3b9db5a1e5c94435d598dda73019d5e323fd253c"
   package: "ruby-2.5.8-p0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.gz" "71e7b22d1dfa32d3df0bfeec48237b28a53bc04f"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.5.8-p0.7z" "3b9db5a1e5c94435d598dda73019d5e323fd253c"
   package: "ruby-2.5.8-p0" "https://ruby.kaos.st/ruby-2.5.8.7z" "17df6dc748a4e94be31f469dbede4bfeceb13994"

--- a/SOURCES/defs/2.6.0
+++ b/SOURCES/defs/2.6.0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.gz" "c95f4e86e21390270dad3ebb94491fd42ee2ce69"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
   package: "ruby-2.6.0-p0" "https://ruby.kaos.st/ruby-2.6.0.7z" "f1d5a0559236d20736e9bcc7c2aca5aec073da30"

--- a/SOURCES/defs/2.6.0-jemalloc
+++ b/SOURCES/defs/2.6.0-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.0-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.gz" "c95f4e86e21390270dad3ebb94491fd42ee2ce69"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
   package: "ruby-2.6.0-p0" "https://ruby.kaos.st/ruby-2.6.0.7z" "f1d5a0559236d20736e9bcc7c2aca5aec073da30"

--- a/SOURCES/defs/2.6.0-railsexpress
+++ b/SOURCES/defs/2.6.0-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.0-p0.7z" "9bb4a1eb091339d0a507c23e49cda998b4ac9f1e"
   package: "ruby-2.6.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.gz" "c95f4e86e21390270dad3ebb94491fd42ee2ce69"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.0-p0.7z" "9bb4a1eb091339d0a507c23e49cda998b4ac9f1e"
   package: "ruby-2.6.0-p0" "https://ruby.kaos.st/ruby-2.6.0.7z" "f1d5a0559236d20736e9bcc7c2aca5aec073da30"

--- a/SOURCES/defs/2.6.1
+++ b/SOURCES/defs/2.6.1
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.gz" "416842bb5b4ca655610df1f0389b6e21d25154f8"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
   package: "ruby-2.6.1-p0" "https://ruby.kaos.st/ruby-2.6.1.7z" "5048182d8fc4fc2b2c911ee5ca383a66ff2e14c7"

--- a/SOURCES/defs/2.6.1-jemalloc
+++ b/SOURCES/defs/2.6.1-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.1-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.gz" "416842bb5b4ca655610df1f0389b6e21d25154f8"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1.7z" "35b1d6ade0551b4fc1ff62bd9b9042fff5ee3b2a" openssl
   package: "ruby-2.6.1-p0" "https://ruby.kaos.st/ruby-2.6.1.7z" "5048182d8fc4fc2b2c911ee5ca383a66ff2e14c7"

--- a/SOURCES/defs/2.6.1-railsexpress
+++ b/SOURCES/defs/2.6.1-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.1-p0.7z" "68753d52cc43d46f7eb3c3cf6424ddd78ffc9669"
   package: "ruby-2.6.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.gz" "416842bb5b4ca655610df1f0389b6e21d25154f8"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.1-p0.7z" "68753d52cc43d46f7eb3c3cf6424ddd78ffc9669"
   package: "ruby-2.6.1-p0" "https://ruby.kaos.st/ruby-2.6.1.7z" "5048182d8fc4fc2b2c911ee5ca383a66ff2e14c7"

--- a/SOURCES/defs/2.6.2
+++ b/SOURCES/defs/2.6.2
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.gz" "44c6634a41f63ebdc1f3ce6ddcf48a4766bb4df7"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.6.2-p0" "https://ruby.kaos.st/ruby-2.6.2.7z" "c76b54231329fb63e0a9efd08b37b68f353824e2"

--- a/SOURCES/defs/2.6.2-jemalloc
+++ b/SOURCES/defs/2.6.2-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.2-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.gz" "44c6634a41f63ebdc1f3ce6ddcf48a4766bb4df7"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.6.2-p0" "https://ruby.kaos.st/ruby-2.6.2.7z" "c76b54231329fb63e0a9efd08b37b68f353824e2"

--- a/SOURCES/defs/2.6.2-railsexpress
+++ b/SOURCES/defs/2.6.2-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.2-p0.7z" "63ec31ecb3a4fab5ea209e32a9225cddf9a37c5e"
   package: "ruby-2.6.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.gz" "44c6634a41f63ebdc1f3ce6ddcf48a4766bb4df7"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.2-p0.7z" "63ec31ecb3a4fab5ea209e32a9225cddf9a37c5e"
   package: "ruby-2.6.2-p0" "https://ruby.kaos.st/ruby-2.6.2.7z" "c76b54231329fb63e0a9efd08b37b68f353824e2"

--- a/SOURCES/defs/2.6.3
+++ b/SOURCES/defs/2.6.3
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.gz" "2347ed6ca5490a104ebd5684d2b9b5eefa6cd33c"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.6.3-p0" "https://ruby.kaos.st/ruby-2.6.3.7z" "f44751129cd806ebe6eeedddf336b6fb4823be13"

--- a/SOURCES/defs/2.6.3-jemalloc
+++ b/SOURCES/defs/2.6.3-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.3-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.gz" "2347ed6ca5490a104ebd5684d2b9b5eefa6cd33c"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.6.3-p0" "https://ruby.kaos.st/ruby-2.6.3.7z" "f44751129cd806ebe6eeedddf336b6fb4823be13"

--- a/SOURCES/defs/2.6.3-railsexpress
+++ b/SOURCES/defs/2.6.3-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:14 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.3-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.3-p0.7z" "ea16bfddae3f33c54fd9bcc2e75340c20f441484"
   package: "ruby-2.6.3-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.gz" "2347ed6ca5490a104ebd5684d2b9b5eefa6cd33c"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.3-p0.7z" "ea16bfddae3f33c54fd9bcc2e75340c20f441484"
   package: "ruby-2.6.3-p0" "https://ruby.kaos.st/ruby-2.6.3.7z" "f44751129cd806ebe6eeedddf336b6fb4823be13"

--- a/SOURCES/defs/2.6.4
+++ b/SOURCES/defs/2.6.4
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.gz" "2eaddc428cb5d210cfc256a7e6947196ed24355b"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.6.4-p0" "https://ruby.kaos.st/ruby-2.6.4.7z" "61b6950d748fda8554781af27cf4a289ebc16dbf"

--- a/SOURCES/defs/2.6.4-jemalloc
+++ b/SOURCES/defs/2.6.4-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.4-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.gz" "2eaddc428cb5d210cfc256a7e6947196ed24355b"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.6.4-p0" "https://ruby.kaos.st/ruby-2.6.4.7z" "61b6950d748fda8554781af27cf4a289ebc16dbf"

--- a/SOURCES/defs/2.6.4-railsexpress
+++ b/SOURCES/defs/2.6.4-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.4-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.4-p0.7z" "4484dc90804167034faf9fa367ef1997b7de70d9"
   package: "ruby-2.6.4-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.gz" "2eaddc428cb5d210cfc256a7e6947196ed24355b"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.4-p0.7z" "4484dc90804167034faf9fa367ef1997b7de70d9"
   package: "ruby-2.6.4-p0" "https://ruby.kaos.st/ruby-2.6.4.7z" "61b6950d748fda8554781af27cf4a289ebc16dbf"

--- a/SOURCES/defs/2.6.5
+++ b/SOURCES/defs/2.6.5
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.gz" "1416ce288fb8bfeae07a12b608540318c9cace71"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.6.5-p0" "https://ruby.kaos.st/ruby-2.6.5.7z" "5994df0b447ca3c09900a76a9664cf6038033fe0"

--- a/SOURCES/defs/2.6.5-jemalloc
+++ b/SOURCES/defs/2.6.5-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.5-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.gz" "1416ce288fb8bfeae07a12b608540318c9cace71"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.6.5-p0" "https://ruby.kaos.st/ruby-2.6.5.7z" "5994df0b447ca3c09900a76a9664cf6038033fe0"

--- a/SOURCES/defs/2.6.5-railsexpress
+++ b/SOURCES/defs/2.6.5-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.5-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.5-p0.7z" "d1804925ffc759d567e2a3786c5c39b35802d837"
   package: "ruby-2.6.5-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.gz" "1416ce288fb8bfeae07a12b608540318c9cace71"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.5-p0.7z" "d1804925ffc759d567e2a3786c5c39b35802d837"
   package: "ruby-2.6.5-p0" "https://ruby.kaos.st/ruby-2.6.5.7z" "5994df0b447ca3c09900a76a9664cf6038033fe0"

--- a/SOURCES/defs/2.6.6
+++ b/SOURCES/defs/2.6.6
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.gz" "2d78048e293817f38d4ede4ebc7873013e97bb0b"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.6.6-p0" "https://ruby.kaos.st/ruby-2.6.6.7z" "40cb10841d58c2ef8252d6a1fd66bbd3101b6001"

--- a/SOURCES/defs/2.6.6-jemalloc
+++ b/SOURCES/defs/2.6.6-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.6-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.6.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.gz" "2d78048e293817f38d4ede4ebc7873013e97bb0b"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.6.6-p0" "https://ruby.kaos.st/ruby-2.6.6.7z" "40cb10841d58c2ef8252d6a1fd66bbd3101b6001"

--- a/SOURCES/defs/2.6.6-railsexpress
+++ b/SOURCES/defs/2.6.6-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.6.6-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.6-p0.7z" "16887e9d26a2d16742de1c86e6836c661894f6aa"
   package: "ruby-2.6.6-p0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.gz" "2d78048e293817f38d4ede4ebc7873013e97bb0b"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.6.6-p0.7z" "16887e9d26a2d16742de1c86e6836c661894f6aa"
   package: "ruby-2.6.6-p0" "https://ruby.kaos.st/ruby-2.6.6.7z" "40cb10841d58c2ef8252d6a1fd66bbd3101b6001"

--- a/SOURCES/defs/2.7.0
+++ b/SOURCES/defs/2.7.0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.7.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.gz" "6f4e99b5556010cb27e236873cb8c09eb8317cd5"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.7.0-p0" "https://ruby.kaos.st/ruby-2.7.0.7z" "72452dbd8eb883e962fa4bf370b352252848b842"

--- a/SOURCES/defs/2.7.0-jemalloc
+++ b/SOURCES/defs/2.7.0-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.0-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.7.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.gz" "6f4e99b5556010cb27e236873cb8c09eb8317cd5"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.7.0-p0" "https://ruby.kaos.st/ruby-2.7.0.7z" "72452dbd8eb883e962fa4bf370b352252848b842"

--- a/SOURCES/defs/2.7.0-railsexpress
+++ b/SOURCES/defs/2.7.0-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.7.0-p0.7z" "6bfb620b90b271a4907f00edcd8b978f38405814"
   package: "ruby-2.7.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.gz" "6f4e99b5556010cb27e236873cb8c09eb8317cd5"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.7.0-p0.7z" "6bfb620b90b271a4907f00edcd8b978f38405814"
   package: "ruby-2.7.0-p0" "https://ruby.kaos.st/ruby-2.7.0.7z" "72452dbd8eb883e962fa4bf370b352252848b842"

--- a/SOURCES/defs/2.7.1
+++ b/SOURCES/defs/2.7.1
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.7.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz" "76e25fce50a87f76a3ccd6d0fdd9b7c792400249"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.7.1-p0" "https://ruby.kaos.st/ruby-2.7.1.7z" "93e71b984173ed85bf8e3fa012f29170593cb371"

--- a/SOURCES/defs/2.7.1-jemalloc
+++ b/SOURCES/defs/2.7.1-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.1-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.7.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz" "76e25fce50a87f76a3ccd6d0fdd9b7c792400249"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.7.1-p0" "https://ruby.kaos.st/ruby-2.7.1.7z" "93e71b984173ed85bf8e3fa012f29170593cb371"

--- a/SOURCES/defs/2.7.1-railsexpress
+++ b/SOURCES/defs/2.7.1-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.1-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.7.1-p0.7z" "9dc0a16d3a5d8f4bf7225e5d8b1c09a0801eb639"
   package: "ruby-2.7.1-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz" "76e25fce50a87f76a3ccd6d0fdd9b7c792400249"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.7.1-p0.7z" "9dc0a16d3a5d8f4bf7225e5d8b1c09a0801eb639"
   package: "ruby-2.7.1-p0" "https://ruby.kaos.st/ruby-2.7.1.7z" "93e71b984173ed85bf8e3fa012f29170593cb371"

--- a/SOURCES/defs/2.7.2
+++ b/SOURCES/defs/2.7.2
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.7.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz" "cb9731a17487e0ad84037490a6baf8bfa31a09e8"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.7.2-p0" "https://ruby.kaos.st/ruby-2.7.2.7z" "3285ff509ce2a9825f9fbcd67b652cb894a5f2e8"

--- a/SOURCES/defs/2.7.2-jemalloc
+++ b/SOURCES/defs/2.7.2-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.2-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-2.7.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz" "cb9731a17487e0ad84037490a6baf8bfa31a09e8"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-2.7.2-p0" "https://ruby.kaos.st/ruby-2.7.2.7z" "3285ff509ce2a9825f9fbcd67b652cb894a5f2e8"

--- a/SOURCES/defs/2.7.2-railsexpress
+++ b/SOURCES/defs/2.7.2-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:19:47 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-2.7.2-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/2.7.2-p0.7z" "40c604f6a92409828cc944371274d6555e72e7a6"
   package: "ruby-2.7.2-p0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz" "cb9731a17487e0ad84037490a6baf8bfa31a09e8"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/2.7.2-p0.7z" "40c604f6a92409828cc944371274d6555e72e7a6"
   package: "ruby-2.7.2-p0" "https://ruby.kaos.st/ruby-2.7.2.7z" "3285ff509ce2a9825f9fbcd67b652cb894a5f2e8"

--- a/SOURCES/defs/3.0.0
+++ b/SOURCES/defs/3.0.0
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:42:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:15 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,16 +8,16 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-3.0.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-3.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz" "233873708c1ce9fdc295e0ef1c25e64f9b98b062"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-3.0.0-p0" "https://ruby.kaos.st/ruby-3.0.0.7z" "b591fcbbfd661c2d0a1c17afa8fa2c4aabb76b10"

--- a/SOURCES/defs/3.0.0-jemalloc
+++ b/SOURCES/defs/3.0.0-jemalloc
@@ -1,21 +1,21 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:42:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:16 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-3.0.0-p0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   package: "ruby-3.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz" "233873708c1ce9fdc295e0ef1c25e64f9b98b062"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   package: "ruby-3.0.0-p0" "https://ruby.kaos.st/ruby-3.0.0.7z" "b591fcbbfd661c2d0a1c17afa8fa2c4aabb76b10"

--- a/SOURCES/defs/3.0.0-railsexpress
+++ b/SOURCES/defs/3.0.0-railsexpress
@@ -1,5 +1,5 @@
 # RBBuild Def File
-# UPDATED 06/Feb/2021 01:42:04 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 17/Feb/2021 01:12:16 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): gcc make zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
@@ -8,18 +8,18 @@ deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
 deps(bin): ruby
 
-CONFOPTS(openssl-1.1.1i): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-MAKEOPTS(openssl-1.1.1i): -j 1
-PREFIX(openssl-1.1.1i): {prefix}/openssl
+CONFOPTS(openssl-1.1.1j): {os_name}-{os_arch} --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+MAKEOPTS(openssl-1.1.1j): -j 1
+PREFIX(openssl-1.1.1j): {prefix}/openssl
 
 CONFOPTS(ruby-3.0.0-p0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz" "eb684ba4ed31fe2c48062aead75233ecd36882a6" openssl
+  package: "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz" "04c340b086828eecff9df06dceff196790bb9268" openssl
   patchset: "https://ruby.kaos.st/patches/3.0.0-p0.7z" "26795be7d0e445b06c85b1c3635ace6fb96831c2"
   package: "ruby-3.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz" "233873708c1ce9fdc295e0ef1c25e64f9b98b062"
 
 [essentialkaos]
-  package: "openssl-1.1.1i" "https://ruby.kaos.st/openssl-1.1.1i.7z" "ef3fdabe962210eae4aa9c399be091c4d79ed698" openssl
+  package: "openssl-1.1.1j" "https://ruby.kaos.st/openssl-1.1.1j.7z" "d8e0fdd8becbe283f95c75459a5baa982163fb20" openssl
   patchset: "https://ruby.kaos.st/patches/3.0.0-p0.7z" "26795be7d0e445b06c85b1c3635ace6fb96831c2"
   package: "ruby-3.0.0-p0" "https://ruby.kaos.st/ruby-3.0.0.7z" "b591fcbbfd661c2d0a1c17afa8fa2c4aabb76b10"

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -29,7 +29,7 @@
 
 Summary:         Def files for rbbuild utility
 Name:            rbbuild-defs
-Version:         1.10.2
+Version:         1.10.3
 Release:         0%{?dist}
 License:         Apache License, Version 2.0
 Vendor:          ESSENTIALKAOS
@@ -76,6 +76,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed Feb 17 2021 Anton Novojilov <andy@essentialkaos.com> - 1.10.3-0
+- OpenSSL updated to 1.1.1j for 2.4.0 <-> 3.0.0
+
 * Sat Feb 06 2021 Anton Novojilov <andy@essentialkaos.com> - 1.10.2-0
 - Added 2.7.2-p0
 - Added 2.7.2-p0-jemalloc
@@ -90,7 +93,7 @@ rm -rf %{buildroot}
 - Added truffleruby-20.3.0
 - Added truffleruby-21.0.0
 - OpenSSL updated to 1.0.2u for 1.9.2 <-> 2.3.8
-- OpenSSL updated to 1.1.1f for 2.4.0 <-> 2.7.1
+- OpenSSL updated to 1.1.1i for 2.4.0 <-> 2.7.1
 - Added EOL dates for 2.3.x, 2.4.x, 2.5.x, jruby-9.0.x.x and jruby-9.1.x.x
 
 * Fri Jun 19 2020 Anton Novojilov <andy@essentialkaos.com> - 1.10.1-0


### PR DESCRIPTION
### Improvements
- OpenSSL updated to `1.1.1j` for `2.4.0` - `2.7.1` ([CVE-2021-23840](https://security.archlinux.org/CVE-2021-23840), [CVE-2021-23841](https://security.archlinux.org/CVE-2021-23841))