### PR TITLE
Defs update

### DIFF
--- a/.docker/ol10.docker
+++ b/.docker/ol10.docker
@@ -1,0 +1,50 @@
+## REGISTRY CONFIGURATION ######################################################
+
+ARG REGISTRY="ghcr.io"
+
+## FINAL IMAGE #################################################################
+
+FROM ${REGISTRY}/essentialkaos/oraclelinux:10
+
+ARG HOSTNAME="rbbuild-ol10.docker.local"
+
+LABEL org.opencontainers.image.title="RBBuild" \
+      org.opencontainers.image.description="Image to build Ruby (OracleLinux 10)" \
+      org.opencontainers.image.vendor="ESSENTIAL KAOS" \
+      org.opencontainers.image.authors="Anton Novojilov" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.url="https://kaos.sh/d/rbbuild" \
+      org.opencontainers.image.source="https://github.com/essentialkaos/rbbuild"
+
+# hadolint ignore=DL3031,DL3041
+RUN <<EOF
+  # Configure image environment
+  echo "$HOSTNAME" > /etc/hostname
+  dnf -y -q update oraclelinux-release
+  dnf -y -q install https://pkgs.kaos.st/kaos-repo-latest.el10.noarch.rpm
+  dnf -y -q install https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+  sed -i 's/gpgcheck=1/gpgcheck=1\nmodule_hotfixes=1/g' /etc/yum.repos.d/epel.repo
+  dnf config-manager --set-enabled ol10_codeready_builder
+  dnf -y -q install bash curl zstd patch gawk bc git
+  dnf clean all
+  rm -rf /var/cache/dnf /var/log/dnf.*
+  mkdir -p /usr/libexec/rbbuild \
+           /usr/local/share/rbbuild
+EOF
+
+COPY SOURCES/rbbuild /usr/bin/rbbuild
+COPY SOURCES/rbdef /usr/bin/rbdef
+COPY SOURCES/mass-builder /usr/bin/mass-builder
+COPY SOURCES/libexec/* /usr/libexec/rbbuild/
+COPY SOURCES/defs/* /usr/local/share/rbbuild/
+
+RUN chmod +x /usr/bin/rbbuild \
+             /usr/bin/rbdef \
+             /usr/bin/mass-builder
+
+VOLUME /rbbuild
+WORKDIR /rbbuild
+
+ENTRYPOINT ["/usr/bin/bash"]
+
+################################################################################

--- a/.docker/ol8.docker
+++ b/.docker/ol8.docker
@@ -1,0 +1,50 @@
+## REGISTRY CONFIGURATION ######################################################
+
+ARG REGISTRY="ghcr.io"
+
+## FINAL IMAGE #################################################################
+
+FROM ${REGISTRY}/essentialkaos/oraclelinux:8
+
+ARG HOSTNAME="rbbuild-ol8.docker.local"
+
+LABEL org.opencontainers.image.title="RBBuild" \
+      org.opencontainers.image.description="Image to build Ruby (OracleLinux 8)" \
+      org.opencontainers.image.vendor="ESSENTIAL KAOS" \
+      org.opencontainers.image.authors="Anton Novojilov" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.url="https://kaos.sh/d/rbbuild" \
+      org.opencontainers.image.source="https://github.com/essentialkaos/rbbuild"
+
+# hadolint ignore=DL3031,DL3041
+RUN <<EOF
+  # Configure image environment
+  echo "$HOSTNAME" > /etc/hostname
+  dnf -y -q update oraclelinux-release
+  dnf -y -q install https://pkgs.kaos.st/kaos-repo-latest.el8.noarch.rpm
+  sed -i 's/gpgcheck=1/gpgcheck=1\nmodule_hotfixes=1/g' /etc/yum.repos.d/epel.repo
+  dnf config-manager --set-enabled ol8_codeready_builder
+  dnf -y -q install bash curl zstd patch gawk bc git
+  dnf -y -q remove libevent
+  dnf clean all
+  rm -rf /var/cache/dnf /var/log/dnf.*
+  mkdir -p /usr/libexec/rbbuild \
+           /usr/local/share/rbbuild
+EOF
+
+COPY SOURCES/rbbuild /usr/bin/rbbuild
+COPY SOURCES/rbdef /usr/bin/rbdef
+COPY SOURCES/mass-builder /usr/bin/mass-builder
+COPY SOURCES/libexec/* /usr/libexec/rbbuild/
+COPY SOURCES/defs/* /usr/local/share/rbbuild/
+
+RUN chmod +x /usr/bin/rbbuild \
+             /usr/bin/rbdef \
+             /usr/bin/mass-builder
+
+VOLUME /rbbuild
+WORKDIR /rbbuild
+
+ENTRYPOINT ["/usr/bin/bash"]
+
+################################################################################

--- a/.docker/ol9.docker
+++ b/.docker/ol9.docker
@@ -1,0 +1,50 @@
+## REGISTRY CONFIGURATION ######################################################
+
+ARG REGISTRY="ghcr.io"
+
+## FINAL IMAGE #################################################################
+
+FROM ${REGISTRY}/essentialkaos/oraclelinux:9
+
+ARG HOSTNAME="rbbuild-ol9.docker.local"
+
+LABEL org.opencontainers.image.title="RBBuild" \
+      org.opencontainers.image.description="Image to build Ruby (OracleLinux 9)" \
+      org.opencontainers.image.vendor="ESSENTIAL KAOS" \
+      org.opencontainers.image.authors="Anton Novojilov" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.url="https://kaos.sh/d/rbbuild" \
+      org.opencontainers.image.source="https://github.com/essentialkaos/rbbuild"
+
+# hadolint ignore=DL3031,DL3041
+RUN <<EOF
+  # Configure image environment
+  echo "$HOSTNAME" > /etc/hostname
+  dnf -y -q update oraclelinux-release
+  dnf -y -q install https://pkgs.kaos.st/kaos-repo-latest.el9.noarch.rpm
+  dnf -y -q install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  sed -i 's/gpgcheck=1/gpgcheck=1\nmodule_hotfixes=1/g' /etc/yum.repos.d/epel.repo
+  dnf config-manager --set-enabled ol9_codeready_builder
+  dnf -y -q install bash curl zstd patch gawk bc git
+  dnf clean all
+  rm -rf /var/cache/dnf /var/log/dnf.*
+  mkdir -p /usr/libexec/rbbuild \
+           /usr/local/share/rbbuild
+EOF
+
+COPY SOURCES/rbbuild /usr/bin/rbbuild
+COPY SOURCES/rbdef /usr/bin/rbdef
+COPY SOURCES/mass-builder /usr/bin/mass-builder
+COPY SOURCES/libexec/* /usr/libexec/rbbuild/
+COPY SOURCES/defs/* /usr/local/share/rbbuild/
+
+RUN chmod +x /usr/bin/rbbuild \
+             /usr/bin/rbdef \
+             /usr/bin/mass-builder
+
+VOLUME /rbbuild
+WORKDIR /rbbuild
+
+ENTRYPOINT ["/usr/bin/bash"]
+
+################################################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,59 @@ jobs:
 
       - name: Check spelling
         uses: crate-ci/typos@master
+
+  ImageBuild:
+    name: Image Build Check
+    runs-on: ubuntu-latest
+
+    needs: [Shellcheck, Perfecto]
+
+    env:
+      REGISTRY: ghcr.io
+
+    strategy:
+      matrix:
+        image: [ 'ol8', 'ol9', 'ol10' ]
+
+    steps:
+      - name: Check event type
+        run: |
+          if [[ "${{github.event_name}}" != "pull_request" ]] ; then
+            echo "::notice::Event type is not 'pull_request', all job actions will be skipped"
+          fi
+
+          # This step is a hack for needs+if issue with actions
+          # More info about issue: https://github.com/actions/runner/issues/491
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        if: ${{ github.event_name == 'pull_request' }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        if: ${{ github.event_name == 'pull_request' && env.DOCKERHUB_USERNAME != '' }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker images
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          docker build --build-arg REGISTRY=${REGISTRY} -f .docker/${{matrix.image}}.docker -t ${{matrix.image}} .
+
+      - name: Show info about built Docker images
+        uses: essentialkaos/docker-info-action@v1
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          image: ${{matrix.image}}
+          show-labels: true

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,179 @@
+name: "Docker Push"
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      force_rebuild:
+        description: 'Force container rebuild'
+        required: true
+        type: choice
+        options: [yes, no]
+  schedule:
+    - cron: '30 12 * * *'
+
+permissions:
+  packages: write
+  contents: read
+
+env:
+  IMAGE_NAME: ${{ github.repository }}
+  LATEST_IMAGE: ol9
+
+jobs:
+  Docker:
+    name: Docker Build & Publish
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        image: [ 'ol8', 'ol9', 'ol10' ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Yandex Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: cr.yandex
+          username: oauth
+          password: ${{ secrets.YC_TOKEN }}
+
+      - name: Checkout the latest tag
+        run: |
+          rev=$(git rev-list --tags --max-count=1)
+          tag=$(git describe --tags "$rev")
+
+          if [[ -z "$tag" ]] ; then
+            echo "::error::Can't find the latest tag"
+            exit 1
+          fi
+
+          echo -e "\033[34mRev:\033[0m $rev"
+          echo -e "\033[34mTag:\033[0m $tag"
+
+          git checkout "$tag"
+
+      - name: Prepare metadata for build
+        id: metadata
+        run: |
+          rev=$(git rev-list --tags --max-count=1)
+          version=$(git describe --tags "$rev" | tr -d 'v')
+
+          if [[ -z "$version" ]] ; then
+            echo "::error::Can't find version info"
+            exit 1
+          fi
+
+          docker_file=".docker/${{matrix.image}}.docker"
+          base_image=$(grep 'FROM ' $docker_file | grep -v 'builder' | sed 's#${REGISTRY}/##' | tail -1 | cut -f2 -d' ')
+
+          if [[ -z "$base_image" ]] ; then
+            echo "::error::Can't extract base image info"
+            exit 1
+          fi
+
+          dh_tags="${{env.IMAGE_NAME}}:${{matrix.image}}-$version,${{env.IMAGE_NAME}}:${{matrix.image}}"
+          gh_tags="ghcr.io/${{env.IMAGE_NAME}}:${{matrix.image}}-$version,ghcr.io/${{env.IMAGE_NAME}}:${{matrix.image}}"
+          yc_tags="cr.yandex/${{secrets.YC_REGISTRY_ID}}/${{github.event.repository.name}}:${{matrix.image}}-$version,cr.yandex/${{secrets.YC_REGISTRY_ID}}/${{github.event.repository.name}}:${{matrix.image}}"
+
+          if [[ -n "${{env.LATEST_IMAGE}}" && "${{env.LATEST_IMAGE}}" == "${{matrix.image}}" ]] ; then
+            dh_tags="$dh_tags,${{env.IMAGE_NAME}}:latest"
+            gh_tags="$gh_tags,ghcr.io/${{env.IMAGE_NAME}}:latest"
+            yc_tags="$yc_tags,cr.yandex/${{secrets.YC_REGISTRY_ID}}/${{github.event.repository.name}}:latest"
+          fi
+
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "dockerfile=$docker_file" >> $GITHUB_OUTPUT
+          echo "baseimage=$base_image" >> $GITHUB_OUTPUT
+          echo "dh_tags=$dh_tags" >> $GITHUB_OUTPUT
+          echo "gh_tags=$gh_tags" >> $GITHUB_OUTPUT
+          echo "yc_tags=$yc_tags" >> $GITHUB_OUTPUT
+
+          echo -e "\033[34mVersion:\033[0m    $version"
+          echo -e "\033[34mDockerfile:\033[0m $docker_file"
+          echo -e "\033[34mBase image:\033[0m $base_image"
+          echo -e "\033[34mDH Tags:\033[0m    $dh_tags"
+          echo -e "\033[34mGHCR Tags:\033[0m  $gh_tags"
+
+      - name: Check if build/rebuild is required
+        id: build_check
+        run: |
+          if [[ "${{github.event_name}}" == "release" ]] ; then
+            echo "build=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if [[ "${{ github.event.inputs.force_rebuild }}" == "true" ]] ; then
+            echo "::warning::Rebuild ${{matrix.version}} (reason: forced rebuild)"
+            echo "build=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo -e "::group::\033[34mDownloading built image…\033[0m"
+
+          if ! docker pull ghcr.io/${{env.IMAGE_NAME}}:${{matrix.image}} ; then
+            echo "::error::Can't download image ghcr.io/${{env.IMAGE_NAME}}:${{matrix.image}}"
+            exit 1
+          fi
+
+          echo "::endgroup::"
+          echo -e "::group::\033[34mDownloading base image…\033[0m"
+
+          if ! docker pull ${{steps.metadata.outputs.baseimage}} ; then
+            echo "::error::Can't download image ${{steps.metadata.outputs.baseimage}}"
+            exit 1
+          fi
+
+          echo "::endgroup::"
+
+          base_layer=$(docker inspect "${{steps.metadata.outputs.baseimage}}" | jq -r '.[0].RootFS.Layers[-1]')
+
+          if [[ -z "$base_layer" ]] ; then
+            echo "::error::Can't extract layers info from base image"
+            exit 1
+          fi
+
+          if ! docker inspect "ghcr.io/${{env.IMAGE_NAME}}:${{matrix.image}}" | jq -r '.[0].RootFS.Layers' | grep -q "$base_layer" ; then
+            echo "::warning::Rebuild image (reason: base image rebuilt)"
+            echo "build=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+      - name: Build and push image
+        if: ${{ steps.build_check.outputs.build == 'true' }}
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          file: ${{steps.metadata.outputs.dockerfile}}
+          build-args: |
+            REGISTRY=ghcr.io
+          tags: |
+            ${{ steps.metadata.outputs.dh_tags }}
+            ${{ steps.metadata.outputs.gh_tags }}
+            ${{ steps.metadata.outputs.yc_tags }}
+
+      - name: Show info about built image
+        if: ${{ steps.build_check.outputs.build == 'true' }}
+        uses: essentialkaos/docker-info-action@v1
+        with:
+          image: ghcr.io/${{env.IMAGE_NAME}}:${{matrix.image}}
+          show-labels: true

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,14 @@
 
 ########################################################################################
 
+build-images: ## Build Docker images
+	@echo -e "\e[1;36;49m\nBuilding Oracle Linux 8 image…\n\e[0m"
+	docker build -f .docker/ol8.docker -t ghcr.io/essentialkaos/rbbuild:ol8 .
+	@echo -e "\e[1;36;49m\nBuilding Oracle Linux 9 image…\n\e[0m"
+	docker build -f .docker/ol9.docker -t ghcr.io/essentialkaos/rbbuild:ol9 .
+	@echo -e "\e[1;36;49m\nBuilding Oracle Linux 10 image…\n\e[0m"
+	docker build -f .docker/ol10.docker -t ghcr.io/essentialkaos/rbbuild:ol10 .
+
 get-shellcheck: ## Download and install the latest version of shellcheck (requires sudo)
 ifneq ($(shell id -u), 0)
 	@echo -e "\e[31m▲ This target requires sudo\e[0m"
@@ -58,7 +66,7 @@ endif
 help: ## Show this info
 	@echo -e '\nSupported targets:\n'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
-		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[33m%-18s\033[0m %s\n", $$1, $$2}'
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[33m%-15s\033[0m %s\n", $$1, $$2}'
 	@echo -e ''
 
 ########################################################################################

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
 #### From [ESSENTIAL KAOS Public Repository](https://pkgs.kaos.st)
 
 ```bash
-sudo yum install -y https://pkgs.kaos.st/kaos-repo-latest.el$(grep 'CPE_NAME' /etc/os-release | tr -d '"' | cut -d':' -f5).noarch.rpm
-sudo yum install rbbuild
+sudo dnf install -y https://pkgs.kaos.st/kaos-repo-latest.el$(grep 'CPE_NAME' /etc/os-release | tr -d '"' | cut -d':' -f5).noarch.rpm
+sudo dnf install rbbuild
 ```
 
 #### Using Makefile and Git

--- a/SOURCES/defs/3.1.0
+++ b/SOURCES/defs/3.1.0
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -9,15 +9,15 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.0" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0.tar.gz" "e4e8c20dd2a1fdef4d3e5bd5a3461000dd17f226"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.0" "https://ruby.kaos.st/ruby-3.1.0.tzst" "4086edd31a23f91a3fc9108dd2aa406b61b43bab"

--- a/SOURCES/defs/3.1.0-jemalloc
+++ b/SOURCES/defs/3.1.0-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -7,15 +7,15 @@ eol(security): 2025-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.0" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0.tar.gz" "e4e8c20dd2a1fdef4d3e5bd5a3461000dd17f226"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.0" "https://ruby.kaos.st/ruby-3.1.0.tzst" "4086edd31a23f91a3fc9108dd2aa406b61b43bab"

--- a/SOURCES/defs/3.1.1
+++ b/SOURCES/defs/3.1.1
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -9,15 +9,15 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.1): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.1.tar.gz" "289cbb9eae338bdaf99e376ac511236e39be83a3"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.1" "https://ruby.kaos.st/ruby-3.1.1.tzst" "f1fc75f43d97d8e835d014c3a15da96dbd282d8a"

--- a/SOURCES/defs/3.1.1-jemalloc
+++ b/SOURCES/defs/3.1.1-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -7,15 +7,15 @@ eol(security): 2025-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.1): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.1.tar.gz" "289cbb9eae338bdaf99e376ac511236e39be83a3"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.1" "https://ruby.kaos.st/ruby-3.1.1.tzst" "f1fc75f43d97d8e835d014c3a15da96dbd282d8a"

--- a/SOURCES/defs/3.1.2
+++ b/SOURCES/defs/3.1.2
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -9,15 +9,15 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.2): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.2" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz" "b0d86c60457fdfbcb532cb681877a2f790f66b25"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.2" "https://ruby.kaos.st/ruby-3.1.2.tzst" "2ab16eff9b30f00f4add30e35578450823c74209"

--- a/SOURCES/defs/3.1.2-jemalloc
+++ b/SOURCES/defs/3.1.2-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -7,15 +7,15 @@ eol(security): 2025-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.2): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.2" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz" "b0d86c60457fdfbcb532cb681877a2f790f66b25"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.2" "https://ruby.kaos.st/ruby-3.1.2.tzst" "2ab16eff9b30f00f4add30e35578450823c74209"

--- a/SOURCES/defs/3.1.3
+++ b/SOURCES/defs/3.1.3
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -9,15 +9,15 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.3): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.3" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz" "bd35f56a1cc1760ea582c67cbf669556dc7ae2fd"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.3" "https://ruby.kaos.st/ruby-3.1.3.tzst" "3f350a06f4fe9ca436251195a92f80627082b426"

--- a/SOURCES/defs/3.1.3-jemalloc
+++ b/SOURCES/defs/3.1.3-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -7,15 +7,15 @@ eol(security): 2025-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.3): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.3" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz" "bd35f56a1cc1760ea582c67cbf669556dc7ae2fd"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.3" "https://ruby.kaos.st/ruby-3.1.3.tzst" "3f350a06f4fe9ca436251195a92f80627082b426"

--- a/SOURCES/defs/3.1.4
+++ b/SOURCES/defs/3.1.4
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -9,15 +9,15 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.4): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.4" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.4.tar.gz" "38eddfc5a7536b6c8133183563009a4ed9bbe6db"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.4" "https://ruby.kaos.st/ruby-3.1.4.tzst" "6b2e01dc38b6866b4901cdaf0dc9d49adc3d8fa9"

--- a/SOURCES/defs/3.1.4-jemalloc
+++ b/SOURCES/defs/3.1.4-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -7,15 +7,15 @@ eol(security): 2025-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.4): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.4" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.4.tar.gz" "38eddfc5a7536b6c8133183563009a4ed9bbe6db"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.4" "https://ruby.kaos.st/ruby-3.1.4.tzst" "6b2e01dc38b6866b4901cdaf0dc9d49adc3d8fa9"

--- a/SOURCES/defs/3.1.5
+++ b/SOURCES/defs/3.1.5
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -9,15 +9,15 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.5): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.5" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.gz" "e3387c8fa2b6faf20beade2239ebdfc701ee6268"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.5" "https://ruby.kaos.st/ruby-3.1.5.tzst" "5946aebd2ddc9d413cb013282476d7cfa696e96d"

--- a/SOURCES/defs/3.1.5-jemalloc
+++ b/SOURCES/defs/3.1.5-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -7,15 +7,15 @@ eol(security): 2025-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.5): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.5" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.gz" "e3387c8fa2b6faf20beade2239ebdfc701ee6268"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.5" "https://ruby.kaos.st/ruby-3.1.5.tzst" "5946aebd2ddc9d413cb013282476d7cfa696e96d"

--- a/SOURCES/defs/3.1.6
+++ b/SOURCES/defs/3.1.6
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -9,15 +9,15 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.6): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.6" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.6.tar.gz" "02832465f9b0f68b9fe2c443f9f602d6e840b2ca"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.6" "https://ruby.kaos.st/ruby-3.1.6.tzst" "9092bfcdc4f41c75de9de591d3c186b914712d2a"

--- a/SOURCES/defs/3.1.6-jemalloc
+++ b/SOURCES/defs/3.1.6-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:11 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -7,15 +7,15 @@ eol(security): 2025-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.6): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.6" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.6.tar.gz" "02832465f9b0f68b9fe2c443f9f602d6e840b2ca"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.6" "https://ruby.kaos.st/ruby-3.1.6.tzst" "9092bfcdc4f41c75de9de591d3c186b914712d2a"

--- a/SOURCES/defs/3.1.7
+++ b/SOURCES/defs/3.1.7
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 14/Apr/2025 23:31:20 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:23:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -9,15 +9,15 @@ deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel
 deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.7): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.7" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.7.tar.gz" "c2023f05989241d1f21409b980ffbda83b1cbe7b"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.7" "https://ruby.kaos.st/ruby-3.1.7.tzst" "da599bdba333dda26156da9b027fe5151eda3331"

--- a/SOURCES/defs/3.1.7-jemalloc
+++ b/SOURCES/defs/3.1.7-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 14/Apr/2025 23:31:20 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:10 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2024-03-31
 eol(security): 2025-03-31
@@ -7,15 +7,15 @@ eol(security): 2025-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.1.7): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.1.7" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.7.tar.gz" "c2023f05989241d1f21409b980ffbda83b1cbe7b"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.1.7" "https://ruby.kaos.st/ruby-3.1.7.tzst" "da599bdba333dda26156da9b027fe5151eda3331"

--- a/SOURCES/defs/3.2.0
+++ b/SOURCES/defs/3.2.0
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:41 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.0" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0.tar.gz" "fb4ab2ceba8bf6a5b9bc7bf7cac945cc94f94c2b"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.0" "https://ruby.kaos.st/ruby-3.2.0.tzst" "0ef94a0aae2fd79999d6cb61a58cc8f66609cf2b"

--- a/SOURCES/defs/3.2.0-jemalloc
+++ b/SOURCES/defs/3.2.0-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:41 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.0" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0.tar.gz" "fb4ab2ceba8bf6a5b9bc7bf7cac945cc94f94c2b"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.0" "https://ruby.kaos.st/ruby-3.2.0.tzst" "0ef94a0aae2fd79999d6cb61a58cc8f66609cf2b"

--- a/SOURCES/defs/3.2.1
+++ b/SOURCES/defs/3.2.1
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:41 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.1): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.1.tar.gz" "aa570c9c89dc19090f623dc31083a4fa4e2b8a7b"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.1" "https://ruby.kaos.st/ruby-3.2.1.tzst" "646e4f8e84e302a01e8bd18b341e431fc3ec4df0"

--- a/SOURCES/defs/3.2.1-jemalloc
+++ b/SOURCES/defs/3.2.1-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:41 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.1): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.1.tar.gz" "aa570c9c89dc19090f623dc31083a4fa4e2b8a7b"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.1" "https://ruby.kaos.st/ruby-3.2.1.tzst" "646e4f8e84e302a01e8bd18b341e431fc3ec4df0"

--- a/SOURCES/defs/3.2.2
+++ b/SOURCES/defs/3.2.2
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:41 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.2): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz" "670fce00d83771a1349b116e56a8a3b0ad323769"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.2" "https://ruby.kaos.st/ruby-3.2.2.tzst" "f486809e832f1c90b40e0495c4bcf8ae26831468"

--- a/SOURCES/defs/3.2.2-jemalloc
+++ b/SOURCES/defs/3.2.2-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:41 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.2): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz" "670fce00d83771a1349b116e56a8a3b0ad323769"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.2" "https://ruby.kaos.st/ruby-3.2.2.tzst" "f486809e832f1c90b40e0495c4bcf8ae26831468"

--- a/SOURCES/defs/3.2.3
+++ b/SOURCES/defs/3.2.3
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:41 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.3): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.3.tar.gz" "7f553e514cb42751a61c3a560a7e8d727c6931ca"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.3" "https://ruby.kaos.st/ruby-3.2.3.tzst" "6521ef865c31285b6828b75259b7af76c235846d"

--- a/SOURCES/defs/3.2.3-jemalloc
+++ b/SOURCES/defs/3.2.3-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:41 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.3): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.3.tar.gz" "7f553e514cb42751a61c3a560a7e8d727c6931ca"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.3" "https://ruby.kaos.st/ruby-3.2.3.tzst" "6521ef865c31285b6828b75259b7af76c235846d"

--- a/SOURCES/defs/3.2.4
+++ b/SOURCES/defs/3.2.4
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.4): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.4" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.gz" "a177e809102270f1cd77bf23c6df30c50ee7c107"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.4" "https://ruby.kaos.st/ruby-3.2.4.tzst" "4828d4696f08c026afc99c82b8f29906dafd7d42"

--- a/SOURCES/defs/3.2.4-jemalloc
+++ b/SOURCES/defs/3.2.4-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.4): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.4" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.gz" "a177e809102270f1cd77bf23c6df30c50ee7c107"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.4" "https://ruby.kaos.st/ruby-3.2.4.tzst" "4828d4696f08c026afc99c82b8f29906dafd7d42"

--- a/SOURCES/defs/3.2.5
+++ b/SOURCES/defs/3.2.5
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.5): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.5" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.5.tar.gz" "e5166c947a4d9057b1310710a2a963df12264ac9"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.5" "https://ruby.kaos.st/ruby-3.2.5.tzst" "f16d4f2ccb0b919dfbe3dff28a319fd41e560380"

--- a/SOURCES/defs/3.2.5-jemalloc
+++ b/SOURCES/defs/3.2.5-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.5): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.5" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.5.tar.gz" "e5166c947a4d9057b1310710a2a963df12264ac9"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.5" "https://ruby.kaos.st/ruby-3.2.5.tzst" "f16d4f2ccb0b919dfbe3dff28a319fd41e560380"

--- a/SOURCES/defs/3.2.6
+++ b/SOURCES/defs/3.2.6
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.6): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.6" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.6.tar.gz" "bbf265f5e7a3f480056dc2fa6d600a97cba00713"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.6" "https://ruby.kaos.st/ruby-3.2.6.tzst" "58ad8082451b210753908a8dbd31400b0be2dd9c"

--- a/SOURCES/defs/3.2.6-jemalloc
+++ b/SOURCES/defs/3.2.6-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.6): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.6" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.6.tar.gz" "bbf265f5e7a3f480056dc2fa6d600a97cba00713"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.6" "https://ruby.kaos.st/ruby-3.2.6.tzst" "58ad8082451b210753908a8dbd31400b0be2dd9c"

--- a/SOURCES/defs/3.2.7
+++ b/SOURCES/defs/3.2.7
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.7): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.7" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.7.tar.gz" "c45aa881a7ea1175212d385fe5c8b6e9ff14b2e5"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.7" "https://ruby.kaos.st/ruby-3.2.7.tzst" "d5aecbd792b83c3dbd6f38a917f08687b1d4baab"

--- a/SOURCES/defs/3.2.7-jemalloc
+++ b/SOURCES/defs/3.2.7-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:12 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.7): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.7" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.7.tar.gz" "c45aa881a7ea1175212d385fe5c8b6e9ff14b2e5"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.7" "https://ruby.kaos.st/ruby-3.2.7.tzst" "d5aecbd792b83c3dbd6f38a917f08687b1d4baab"

--- a/SOURCES/defs/3.2.8
+++ b/SOURCES/defs/3.2.8
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 14/Apr/2025 23:31:20 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.8): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.8" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.8.tar.gz" "419ecff4a0f8e805ddb1314344ffad33afde91d8"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.8" "https://ruby.kaos.st/ruby-3.2.8.tzst" "da9b8b69e0e7a76a01a1cdc9c93dad24a202f6e7"

--- a/SOURCES/defs/3.2.8-jemalloc
+++ b/SOURCES/defs/3.2.8-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 14/Apr/2025 23:31:20 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.2.8): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.2.8" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.8.tar.gz" "419ecff4a0f8e805ddb1314344ffad33afde91d8"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.2.8" "https://ruby.kaos.st/ruby-3.2.8.tzst" "da9b8b69e0e7a76a01a1cdc9c93dad24a202f6e7"

--- a/SOURCES/defs/3.2.9
+++ b/SOURCES/defs/3.2.9
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31

--- a/SOURCES/defs/3.2.9
+++ b/SOURCES/defs/3.2.9
@@ -1,0 +1,26 @@
+# -- [RBdef] --
+# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+
+eol(normal): 2025-03-31
+eol(security): 2026-03-31
+
+deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel libyaml-devel
+deps(rpm): rust
+
+deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
+deps(deb): rustc
+
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
+
+CONFOPTS(ruby-3.2.9): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
+  package: "ruby-3.2.9" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.9.tar.gz" "174f37666192a3fdc9cf24e5eddc0cf4d5de0b1e"
+
+[essentialkaos]
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
+  package: "ruby-3.2.9" "https://ruby.kaos.st/ruby-3.2.9.tzst" "5f764047158c7218c821f99ea8065f0396ac63dc"

--- a/SOURCES/defs/3.2.9-jemalloc
+++ b/SOURCES/defs/3.2.9-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:42 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31

--- a/SOURCES/defs/3.2.9-jemalloc
+++ b/SOURCES/defs/3.2.9-jemalloc
@@ -1,0 +1,21 @@
+# -- [RBdef] --
+# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+
+eol(normal): 2025-03-31
+eol(security): 2026-03-31
+
+deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
+
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
+
+CONFOPTS(ruby-3.2.9): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
+  package: "ruby-3.2.9" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.9.tar.gz" "174f37666192a3fdc9cf24e5eddc0cf4d5de0b1e"
+
+[essentialkaos]
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
+  package: "ruby-3.2.9" "https://ruby.kaos.st/ruby-3.2.9.tzst" "5f764047158c7218c821f99ea8065f0396ac63dc"

--- a/SOURCES/defs/3.3.0
+++ b/SOURCES/defs/3.3.0
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.0" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0.tar.gz" "1a7e56851bf29bda1183aca99b3b323c58e0187b"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.0" "https://ruby.kaos.st/ruby-3.3.0.tzst" "764abe3dd32b7896e7efe16950c9f66590a2cdce"

--- a/SOURCES/defs/3.3.0-jemalloc
+++ b/SOURCES/defs/3.3.0-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.0" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0.tar.gz" "1a7e56851bf29bda1183aca99b3b323c58e0187b"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.0" "https://ruby.kaos.st/ruby-3.3.0.tzst" "764abe3dd32b7896e7efe16950c9f66590a2cdce"

--- a/SOURCES/defs/3.3.1
+++ b/SOURCES/defs/3.3.1
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.1): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.1" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.gz" "affd82947d7cd84bd586f7f487a1da0c0bd8b1fd"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.1" "https://ruby.kaos.st/ruby-3.3.1.tzst" "ef3c9d0834cdfd8d9ed4a64d1c6dd9295774e2c8"

--- a/SOURCES/defs/3.3.1-jemalloc
+++ b/SOURCES/defs/3.3.1-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:44 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.1): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.1" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.gz" "affd82947d7cd84bd586f7f487a1da0c0bd8b1fd"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.1" "https://ruby.kaos.st/ruby-3.3.1.tzst" "ef3c9d0834cdfd8d9ed4a64d1c6dd9295774e2c8"

--- a/SOURCES/defs/3.3.2
+++ b/SOURCES/defs/3.3.2
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.2): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.2" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.2.tar.gz" "b49719ef383c581008c1fd3b68690f874f78557b"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.2" "https://ruby.kaos.st/ruby-3.3.2.tzst" "c2e4756f4b66f0b79d71910f16f698b994f81883"

--- a/SOURCES/defs/3.3.2-jemalloc
+++ b/SOURCES/defs/3.3.2-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.2): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.2" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.2.tar.gz" "b49719ef383c581008c1fd3b68690f874f78557b"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.2" "https://ruby.kaos.st/ruby-3.3.2.tzst" "c2e4756f4b66f0b79d71910f16f698b994f81883"

--- a/SOURCES/defs/3.3.3
+++ b/SOURCES/defs/3.3.3
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.3): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.3" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.3.tar.gz" "b71971b141ee2325d99046a02291940fcca9830c"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.3" "https://ruby.kaos.st/ruby-3.3.3.tzst" "c88920e40cc49a6c070e69992dd22f47aa0b3734"

--- a/SOURCES/defs/3.3.3-jemalloc
+++ b/SOURCES/defs/3.3.3-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.3): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.3" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.3.tar.gz" "b71971b141ee2325d99046a02291940fcca9830c"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.3" "https://ruby.kaos.st/ruby-3.3.3.tzst" "c88920e40cc49a6c070e69992dd22f47aa0b3734"

--- a/SOURCES/defs/3.3.4
+++ b/SOURCES/defs/3.3.4
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.4): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.4" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.4.tar.gz" "408362dfb0413122e09d35bafdcced8922b54e71"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.4" "https://ruby.kaos.st/ruby-3.3.4.tzst" "b6a922d4e3d03f72a19a2ce36cbc6535dbfd1a2a"

--- a/SOURCES/defs/3.3.4-jemalloc
+++ b/SOURCES/defs/3.3.4-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.4): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.4" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.4.tar.gz" "408362dfb0413122e09d35bafdcced8922b54e71"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.4" "https://ruby.kaos.st/ruby-3.3.4.tzst" "b6a922d4e3d03f72a19a2ce36cbc6535dbfd1a2a"

--- a/SOURCES/defs/3.3.5
+++ b/SOURCES/defs/3.3.5
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.5): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.5" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.5.tar.gz" "59444476bbe9e789fc777d8fb4dd456bc057604f"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.5" "https://ruby.kaos.st/ruby-3.3.5.tzst" "14f495a460e13aadf8e789784ccfbbd70b9bf949"

--- a/SOURCES/defs/3.3.5-jemalloc
+++ b/SOURCES/defs/3.3.5-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.5): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.5" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.5.tar.gz" "59444476bbe9e789fc777d8fb4dd456bc057604f"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.5" "https://ruby.kaos.st/ruby-3.3.5.tzst" "14f495a460e13aadf8e789784ccfbbd70b9bf949"

--- a/SOURCES/defs/3.3.6
+++ b/SOURCES/defs/3.3.6
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.6): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.6" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.6.tar.gz" "0106171cd1801fb5663e8e709f3d6c935d683c9b"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.6" "https://ruby.kaos.st/ruby-3.3.6.tzst" "5403d44547ff3fe96ae51db607d0f8960c18a190"

--- a/SOURCES/defs/3.3.6-jemalloc
+++ b/SOURCES/defs/3.3.6-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.6): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.6" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.6.tar.gz" "0106171cd1801fb5663e8e709f3d6c935d683c9b"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.6" "https://ruby.kaos.st/ruby-3.3.6.tzst" "5403d44547ff3fe96ae51db607d0f8960c18a190"

--- a/SOURCES/defs/3.3.7
+++ b/SOURCES/defs/3.3.7
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.7): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.7" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.7.tar.gz" "aaa94abd1a5676dd24e927876935597a505e2a4d"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.7" "https://ruby.kaos.st/ruby-3.3.7.tzst" "5e83333bd42ec7751a7265810ca043693da35d7c"

--- a/SOURCES/defs/3.3.7-jemalloc
+++ b/SOURCES/defs/3.3.7-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:13 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.7): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.7" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.7.tar.gz" "aaa94abd1a5676dd24e927876935597a505e2a4d"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.7" "https://ruby.kaos.st/ruby-3.3.7.tzst" "5e83333bd42ec7751a7265810ca043693da35d7c"

--- a/SOURCES/defs/3.3.8
+++ b/SOURCES/defs/3.3.8
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 14/Apr/2025 23:31:20 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.8): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.8" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.8.tar.gz" "71b8362d413f58ed5aef2ecd132769210c45f058"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.8" "https://ruby.kaos.st/ruby-3.3.8.tzst" "1798f6cd1f1c796c5222c4c3cff4f04cfcb9fffb"

--- a/SOURCES/defs/3.3.8-jemalloc
+++ b/SOURCES/defs/3.3.8-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 14/Apr/2025 23:31:20 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:45 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.3.8): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.3.8" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.8.tar.gz" "71b8362d413f58ed5aef2ecd132769210c45f058"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.3.8" "https://ruby.kaos.st/ruby-3.3.8.tzst" "1798f6cd1f1c796c5222c4c3cff4f04cfcb9fffb"

--- a/SOURCES/defs/3.3.9
+++ b/SOURCES/defs/3.3.9
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31

--- a/SOURCES/defs/3.3.9
+++ b/SOURCES/defs/3.3.9
@@ -1,0 +1,26 @@
+# -- [RBdef] --
+# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+
+eol(normal): 2025-03-31
+eol(security): 2026-03-31
+
+deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel libyaml-devel
+deps(rpm): rust
+
+deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
+deps(deb): rustc
+
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
+
+CONFOPTS(ruby-3.3.9): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
+  package: "ruby-3.3.9" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.9.tar.gz" "26c37cff59c72a9249fa5fd3d9a301f320315ea1"
+
+[essentialkaos]
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
+  package: "ruby-3.3.9" "https://ruby.kaos.st/ruby-3.3.9.tzst" "23102ce88d16866e87752c3ce03677e6d88dc5cb"

--- a/SOURCES/defs/3.3.9-jemalloc
+++ b/SOURCES/defs/3.3.9-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:46 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31

--- a/SOURCES/defs/3.3.9-jemalloc
+++ b/SOURCES/defs/3.3.9-jemalloc
@@ -1,0 +1,21 @@
+# -- [RBdef] --
+# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+
+eol(normal): 2025-03-31
+eol(security): 2026-03-31
+
+deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
+
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
+
+CONFOPTS(ruby-3.3.9): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
+  package: "ruby-3.3.9" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.9.tar.gz" "26c37cff59c72a9249fa5fd3d9a301f320315ea1"
+
+[essentialkaos]
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
+  package: "ruby-3.3.9" "https://ruby.kaos.st/ruby-3.3.9.tzst" "23102ce88d16866e87752c3ce03677e6d88dc5cb"

--- a/SOURCES/defs/3.4.0
+++ b/SOURCES/defs/3.4.0
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:14 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.4.0): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.4.0" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.0.tar.gz" "8ccb561848a7c460ae08e1a120a47c4a88a79335"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.4.0" "https://ruby.kaos.st/ruby-3.4.0.tzst" "05b5ad6babe8f4b9ffe7c7276f22f3f22d4680a8"

--- a/SOURCES/defs/3.4.0-jemalloc
+++ b/SOURCES/defs/3.4.0-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:14 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.4.0): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.4.0" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.0.tar.gz" "8ccb561848a7c460ae08e1a120a47c4a88a79335"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.4.0" "https://ruby.kaos.st/ruby-3.4.0.tzst" "05b5ad6babe8f4b9ffe7c7276f22f3f22d4680a8"

--- a/SOURCES/defs/3.4.1
+++ b/SOURCES/defs/3.4.1
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:14 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.4.1): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.4.1" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.1.tar.gz" "dc42fe22bcdfbd30f63cd93296d893c53b1dadcc"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.4.1" "https://ruby.kaos.st/ruby-3.4.1.tzst" "955d6e192074737a8a17fb013cb84b72e096341c"

--- a/SOURCES/defs/3.4.1-jemalloc
+++ b/SOURCES/defs/3.4.1-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:14 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.4.1): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.4.1" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.1.tar.gz" "dc42fe22bcdfbd30f63cd93296d893c53b1dadcc"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.4.1" "https://ruby.kaos.st/ruby-3.4.1.tzst" "955d6e192074737a8a17fb013cb84b72e096341c"

--- a/SOURCES/defs/3.4.2
+++ b/SOURCES/defs/3.4.2
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:14 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -12,15 +12,15 @@ deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
 deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
 deps(deb): rustc
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.4.2): --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.4.2" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.2.tar.gz" "1537911b4a47940f11c309898e04187344a43167"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.4.2" "https://ruby.kaos.st/ruby-3.4.2.tzst" "0dbacdc7e7033107e7ef4dcab43e198889e5abb3"

--- a/SOURCES/defs/3.4.2-jemalloc
+++ b/SOURCES/defs/3.4.2-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 20/Feb/2025 23:05:14 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31
@@ -7,15 +7,15 @@ eol(security): 2026-03-31
 deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
 deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
 
-CONFOPTS(openssl-3.0.16): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
-PREFIX(openssl-3.0.16): {prefix}/openssl
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
 
 CONFOPTS(ruby-3.4.2): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
 
 [default]
-  package: "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz" "9f2b9d6aa10576a5938b5a9cbc777af3ff51d64a" openssl
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
   package: "ruby-3.4.2" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.2.tar.gz" "1537911b4a47940f11c309898e04187344a43167"
 
 [essentialkaos]
-  package: "openssl-3.0.16" "https://ruby.kaos.st/openssl-3.0.16.tzst" "75e05b3e5caf38072b7a51f1e39bcb0692b2b777" openssl
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
   package: "ruby-3.4.2" "https://ruby.kaos.st/ruby-3.4.2.tzst" "0dbacdc7e7033107e7ef4dcab43e198889e5abb3"

--- a/SOURCES/defs/3.4.3
+++ b/SOURCES/defs/3.4.3
@@ -1,0 +1,26 @@
+# -- [RBdef] --
+# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+
+eol(normal): 2025-03-31
+eol(security): 2026-03-31
+
+deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel libyaml-devel
+deps(rpm): rust
+
+deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
+deps(deb): rustc
+
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
+
+CONFOPTS(ruby-3.4.3): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
+  package: "ruby-3.4.3" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.3.tar.gz" "c269cd122ab9d4620a1e0e6a8f4de378deec3799"
+
+[essentialkaos]
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
+  package: "ruby-3.4.3" "https://ruby.kaos.st/ruby-3.4.3.tzst" "7f3b675951e6a653ecd438acd1842ddf4da43101"

--- a/SOURCES/defs/3.4.3
+++ b/SOURCES/defs/3.4.3
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31

--- a/SOURCES/defs/3.4.3-jemalloc
+++ b/SOURCES/defs/3.4.3-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31

--- a/SOURCES/defs/3.4.3-jemalloc
+++ b/SOURCES/defs/3.4.3-jemalloc
@@ -1,0 +1,21 @@
+# -- [RBdef] --
+# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+
+eol(normal): 2025-03-31
+eol(security): 2026-03-31
+
+deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
+
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
+
+CONFOPTS(ruby-3.4.3): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
+  package: "ruby-3.4.3" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.3.tar.gz" "c269cd122ab9d4620a1e0e6a8f4de378deec3799"
+
+[essentialkaos]
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
+  package: "ruby-3.4.3" "https://ruby.kaos.st/ruby-3.4.3.tzst" "7f3b675951e6a653ecd438acd1842ddf4da43101"

--- a/SOURCES/defs/3.4.4
+++ b/SOURCES/defs/3.4.4
@@ -1,0 +1,26 @@
+# -- [RBdef] --
+# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+
+eol(normal): 2025-03-31
+eol(security): 2026-03-31
+
+deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel libyaml-devel
+deps(rpm): rust
+
+deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
+deps(deb): rustc
+
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
+
+CONFOPTS(ruby-3.4.4): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
+  package: "ruby-3.4.4" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.4.tar.gz" "aff18f17868d076f4516ea4209931ad55b264f73"
+
+[essentialkaos]
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
+  package: "ruby-3.4.4" "https://ruby.kaos.st/ruby-3.4.4.tzst" "aaea8fdea52ee3028dc839ed8992b6dd3b20c35e"

--- a/SOURCES/defs/3.4.4
+++ b/SOURCES/defs/3.4.4
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 22/Aug/2025 15:09:38 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31

--- a/SOURCES/defs/3.4.4-jemalloc
+++ b/SOURCES/defs/3.4.4-jemalloc
@@ -1,0 +1,21 @@
+# -- [RBdef] --
+# UPDATED 22/Aug/2025 15:09:39 by Anton Novojilov <andy@essentialkaos.com>
+
+eol(normal): 2025-03-31
+eol(security): 2026-03-31
+
+deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
+
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
+
+CONFOPTS(ruby-3.4.4): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
+  package: "ruby-3.4.4" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.4.tar.gz" "aff18f17868d076f4516ea4209931ad55b264f73"
+
+[essentialkaos]
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
+  package: "ruby-3.4.4" "https://ruby.kaos.st/ruby-3.4.4.tzst" "aaea8fdea52ee3028dc839ed8992b6dd3b20c35e"

--- a/SOURCES/defs/3.4.4-jemalloc
+++ b/SOURCES/defs/3.4.4-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 22/Aug/2025 15:09:39 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31

--- a/SOURCES/defs/3.4.5
+++ b/SOURCES/defs/3.4.5
@@ -1,0 +1,26 @@
+# -- [RBdef] --
+# UPDATED 22/Aug/2025 15:09:39 by Anton Novojilov <andy@essentialkaos.com>
+
+eol(normal): 2025-03-31
+eol(security): 2026-03-31
+
+deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel libyaml-devel
+deps(rpm): rust
+
+deps(deb): build-essential zlib1g-dev libreadline6-dev tk-dev ca-certificates
+deps(deb): autoconf libc6-dev libncurses5-dev bison libffi-dev libyaml-dev
+deps(deb): rustc
+
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
+
+CONFOPTS(ruby-3.4.5): --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
+  package: "ruby-3.4.5" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.5.tar.gz" "ae40a537434bf432aa3b828bc4d13a295854cf40"
+
+[essentialkaos]
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
+  package: "ruby-3.4.5" "https://ruby.kaos.st/ruby-3.4.5.tzst" "f2f8f0bc74a2c311f059f0bd04f835629364323c"

--- a/SOURCES/defs/3.4.5
+++ b/SOURCES/defs/3.4.5
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 22/Aug/2025 15:09:39 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31

--- a/SOURCES/defs/3.4.5-jemalloc
+++ b/SOURCES/defs/3.4.5-jemalloc
@@ -1,0 +1,21 @@
+# -- [RBdef] --
+# UPDATED 22/Aug/2025 15:09:39 by Anton Novojilov <andy@essentialkaos.com>
+
+eol(normal): 2025-03-31
+eol(security): 2026-03-31
+
+deps(rpm): make gcc gcc-c++ zlib-devel readline-devel tk-devel ca-certificates libyaml-devel
+deps(rpm): autoconf glibc-devel ncurses-devel bison libffi-devel jemalloc-devel rust
+
+CONFOPTS(openssl-3.0.17): {os_name}-{os_arch} --libdir=lib --openssldir={prefix}/openssl/ssl zlib-dynamic no-ssl3 shared -fPIC
+PREFIX(openssl-3.0.17): {prefix}/openssl
+
+CONFOPTS(ruby-3.4.5): --with-jemalloc --with-openssl-dir={prefix}/openssl --disable-install-doc
+
+[default]
+  package: "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz" "2e2718ff608eca5c8c56b9343816b6e2fd33fbec" openssl
+  package: "ruby-3.4.5" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.5.tar.gz" "ae40a537434bf432aa3b828bc4d13a295854cf40"
+
+[essentialkaos]
+  package: "openssl-3.0.17" "https://ruby.kaos.st/openssl-3.0.17.tzst" "7741f15196b77c62663498b1bc6fb3962ca89cce" openssl
+  package: "ruby-3.4.5" "https://ruby.kaos.st/ruby-3.4.5.tzst" "f2f8f0bc74a2c311f059f0bd04f835629364323c"

--- a/SOURCES/defs/3.4.5-jemalloc
+++ b/SOURCES/defs/3.4.5-jemalloc
@@ -1,5 +1,5 @@
 # -- [RBdef] --
-# UPDATED 22/Aug/2025 15:09:39 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:24:48 by Anton Novojilov <andy@essentialkaos.com>
 
 eol(normal): 2025-03-31
 eol(security): 2026-03-31

--- a/SOURCES/defs/jruby-10.0.0.0
+++ b/SOURCES/defs/jruby-10.0.0.0
@@ -1,0 +1,11 @@
+# -- [RBdef] --
+# UPDATED 15/Apr/2025 14:38:46 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): make gcc gcc-c++ jre21
+deps(deb): make gcc build-essentials openjdk-11
+
+[default]
+  package: "jruby-10.0.0.0" "https://s3.amazonaws.com/jruby.org/downloads/10.0.0.0/jruby-bin-10.0.0.0.tar.gz" "6c3fdec21aee16343f3735eb5940a59bc0d6a26e" jruby
+
+[essentialkaos]
+  package: "jruby-10.0.0.0" "https://ruby.kaos.st/jruby-10.0.0.0.tzst" "983f07c277d1ede901b627ae65335759c11f9a33" jruby

--- a/SOURCES/defs/jruby-10.0.0.0
+++ b/SOURCES/defs/jruby-10.0.0.0
@@ -5,7 +5,7 @@ deps(rpm): make gcc gcc-c++ jre21
 deps(deb): make gcc build-essentials openjdk-11
 
 [default]
-  package: "jruby-10.0.0.0" "https://s3.amazonaws.com/jruby.org/downloads/10.0.0.0/jruby-bin-10.0.0.0.tar.gz" "6c3fdec21aee16343f3735eb5940a59bc0d6a26e" jruby
+  package: "jruby-10.0.0.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/10.0.0.0/jruby-bin-10.0.0.0.tar.gz" "6c3fdec21aee16343f3735eb5940a59bc0d6a26e" jruby
 
 [essentialkaos]
   package: "jruby-10.0.0.0" "https://ruby.kaos.st/jruby-10.0.0.0.tzst" "983f07c277d1ede901b627ae65335759c11f9a33" jruby

--- a/SOURCES/defs/jruby-10.0.0.1
+++ b/SOURCES/defs/jruby-10.0.0.1
@@ -1,11 +1,11 @@
 # -- [RBdef] --
-# UPDATED 15/Apr/2025 14:38:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:00:41 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): make gcc gcc-c++ jre21
 deps(deb): make gcc build-essentials openjdk-11
 
 [default]
-  package: "jruby-10.0.0.1" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/10.0.0.1/jruby-dist-10.0.0.1-bin.tar.gz" "!" jruby
+  package: "jruby-10.0.0.1" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/10.0.0.1/jruby-dist-10.0.0.1-bin.tar.gz" "2a0ff2f01b36eae9f900b7d0d120f33bdc4554e2" jruby
 
 [essentialkaos]
-  package: "jruby-10.0.0.1" "https://ruby.kaos.st/jruby-10.0.0.1.tzst" "!" jruby
+  package: "jruby-10.0.0.1" "https://ruby.kaos.st/jruby-10.0.0.1.tzst" "486097aec80062190c81622bc72c28c8b06990a6" jruby

--- a/SOURCES/defs/jruby-10.0.0.1
+++ b/SOURCES/defs/jruby-10.0.0.1
@@ -1,0 +1,11 @@
+# -- [RBdef] --
+# UPDATED 15/Apr/2025 14:38:46 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): make gcc gcc-c++ jre21
+deps(deb): make gcc build-essentials openjdk-11
+
+[default]
+  package: "jruby-10.0.0.1" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/10.0.0.1/jruby-dist-10.0.0.1-bin.tar.gz" "!" jruby
+
+[essentialkaos]
+  package: "jruby-10.0.0.1" "https://ruby.kaos.st/jruby-10.0.0.1.tzst" "!" jruby

--- a/SOURCES/defs/jruby-10.0.1.0
+++ b/SOURCES/defs/jruby-10.0.1.0
@@ -1,0 +1,11 @@
+# -- [RBdef] --
+# UPDATED 15/Apr/2025 14:38:46 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): make gcc gcc-c++ jre21
+deps(deb): make gcc build-essentials openjdk-11
+
+[default]
+  package: "jruby-10.0.1.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/10.0.1.0/jruby-dist-10.0.1.0-bin.tar.gz" "!" jruby
+
+[essentialkaos]
+  package: "jruby-10.0.1.0" "https://ruby.kaos.st/jruby-10.0.1.0.tzst" "!" jruby

--- a/SOURCES/defs/jruby-10.0.1.0
+++ b/SOURCES/defs/jruby-10.0.1.0
@@ -1,11 +1,11 @@
 # -- [RBdef] --
-# UPDATED 15/Apr/2025 14:38:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:00:41 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): make gcc gcc-c++ jre21
 deps(deb): make gcc build-essentials openjdk-11
 
 [default]
-  package: "jruby-10.0.1.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/10.0.1.0/jruby-dist-10.0.1.0-bin.tar.gz" "!" jruby
+  package: "jruby-10.0.1.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/10.0.1.0/jruby-dist-10.0.1.0-bin.tar.gz" "52bfb5c543c4d129b67d9adba5dbe203b7a2fc29" jruby
 
 [essentialkaos]
-  package: "jruby-10.0.1.0" "https://ruby.kaos.st/jruby-10.0.1.0.tzst" "!" jruby
+  package: "jruby-10.0.1.0" "https://ruby.kaos.st/jruby-10.0.1.0.tzst" "3ace9bcbca4c69adb043b45a2ceafb6d4c67d3d1" jruby

--- a/SOURCES/defs/jruby-10.0.2.0
+++ b/SOURCES/defs/jruby-10.0.2.0
@@ -1,11 +1,11 @@
 # -- [RBdef] --
-# UPDATED 15/Apr/2025 14:38:46 by Anton Novojilov <andy@essentialkaos.com>
+# UPDATED 22/Aug/2025 15:00:41 by Anton Novojilov <andy@essentialkaos.com>
 
 deps(rpm): make gcc gcc-c++ jre21
 deps(deb): make gcc build-essentials openjdk-11
 
 [default]
-  package: "jruby-10.0.2.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/10.0.2.0/jruby-dist-10.0.2.0-bin.tar.gz" "!" jruby
+  package: "jruby-10.0.2.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/10.0.2.0/jruby-dist-10.0.2.0-bin.tar.gz" "6da46adfdb021a1efb906c779446f47b59eff8a2" jruby
 
 [essentialkaos]
-  package: "jruby-10.0.2.0" "https://ruby.kaos.st/jruby-10.0.2.0.tzst" "!" jruby
+  package: "jruby-10.0.2.0" "https://ruby.kaos.st/jruby-10.0.2.0.tzst" "1e959fa940c9fb4cb91d5a77bc7dd7cc68b41fd0" jruby

--- a/SOURCES/defs/jruby-10.0.2.0
+++ b/SOURCES/defs/jruby-10.0.2.0
@@ -1,0 +1,11 @@
+# -- [RBdef] --
+# UPDATED 15/Apr/2025 14:38:46 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): make gcc gcc-c++ jre21
+deps(deb): make gcc build-essentials openjdk-11
+
+[default]
+  package: "jruby-10.0.2.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/10.0.2.0/jruby-dist-10.0.2.0-bin.tar.gz" "!" jruby
+
+[essentialkaos]
+  package: "jruby-10.0.2.0" "https://ruby.kaos.st/jruby-10.0.2.0.tzst" "!" jruby

--- a/SOURCES/defs/jruby-9.3.0.0
+++ b/SOURCES/defs/jruby-9.3.0.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.0.0/jruby-bin-9.3.0.0.tar.gz" "51406703018e47b849f3796d7712bfcc7e6fec51" jruby
+  package: "jruby-9.3.0.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.0.0/jruby-bin-9.3.0.0.tar.gz" "51406703018e47b849f3796d7712bfcc7e6fec51" jruby
 
 [essentialkaos]
   package: "jruby-9.3.0.0" "https://ruby.kaos.st/jruby-9.3.0.0.tzst" "5e02446de870d471db7ee16f8bda490690f7915d" jruby

--- a/SOURCES/defs/jruby-9.3.1.0
+++ b/SOURCES/defs/jruby-9.3.1.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.1.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.1.0/jruby-bin-9.3.1.0.tar.gz" "e21d2f78e5dfa1fa312be31df33f9821b907aa5a" jruby
+  package: "jruby-9.3.1.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.1.0/jruby-bin-9.3.1.0.tar.gz" "e21d2f78e5dfa1fa312be31df33f9821b907aa5a" jruby
 
 [essentialkaos]
   package: "jruby-9.3.1.0" "https://ruby.kaos.st/jruby-9.3.1.0.tzst" "c6635aa32376975234e21d3696cb5ec10c99f31f" jruby

--- a/SOURCES/defs/jruby-9.3.10.0
+++ b/SOURCES/defs/jruby-9.3.10.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.10.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.10.0/jruby-bin-9.3.10.0.tar.gz" "ceca96e84f1b6a7535654eef27d89d0a3024c76a" jruby
+  package: "jruby-9.3.10.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.10.0/jruby-bin-9.3.10.0.tar.gz" "ceca96e84f1b6a7535654eef27d89d0a3024c76a" jruby
 
 [essentialkaos]
   package: "jruby-9.3.10.0" "https://ruby.kaos.st/jruby-9.3.10.0.tzst" "cc41ff42bc294f8f47a7b7e433d2cfb3ad921975" jruby

--- a/SOURCES/defs/jruby-9.3.11.0
+++ b/SOURCES/defs/jruby-9.3.11.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.11.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.11.0/jruby-bin-9.3.11.0.tar.gz" "82055f66da339721f2cfdda518bc1093c1237aaf" jruby
+  package: "jruby-9.3.11.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.11.0/jruby-bin-9.3.11.0.tar.gz" "82055f66da339721f2cfdda518bc1093c1237aaf" jruby
 
 [essentialkaos]
   package: "jruby-9.3.11.0" "https://ruby.kaos.st/jruby-9.3.11.0.tzst" "fb4ae2c3a7559d2a570b433e6b6adef110214840" jruby

--- a/SOURCES/defs/jruby-9.3.12.0
+++ b/SOURCES/defs/jruby-9.3.12.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.12.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.12.0/jruby-bin-9.3.12.0.tar.gz" "533fc0049e70d0b7571a398973d616a804f300ae" jruby
+  package: "jruby-9.3.12.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.12.0/jruby-bin-9.3.12.0.tar.gz" "533fc0049e70d0b7571a398973d616a804f300ae" jruby
 
 [essentialkaos]
   package: "jruby-9.3.12.0" "https://ruby.kaos.st/jruby-9.3.12.0.tzst" "8c7c09506ad2c6a13ceb2e9aca33059d6ff0041c" jruby

--- a/SOURCES/defs/jruby-9.3.13.0
+++ b/SOURCES/defs/jruby-9.3.13.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.13.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.13.0/jruby-bin-9.3.13.0.tar.gz" "3020ac68e04890e0b80fe78165e464cf384d39d5" jruby
+  package: "jruby-9.3.13.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.13.0/jruby-bin-9.3.13.0.tar.gz" "3020ac68e04890e0b80fe78165e464cf384d39d5" jruby
 
 [essentialkaos]
   package: "jruby-9.3.13.0" "https://ruby.kaos.st/jruby-9.3.13.0.tzst" "3b23b4a7fbd47e4d69aa209948ff0633710f798c" jruby

--- a/SOURCES/defs/jruby-9.3.14.0
+++ b/SOURCES/defs/jruby-9.3.14.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.14.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.14.0/jruby-bin-9.3.14.0.tar.gz" "d9e8dc9ca554efa43c2491d3af01f63bd5ecee8f" jruby
+  package: "jruby-9.3.14.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.14.0/jruby-bin-9.3.14.0.tar.gz" "d9e8dc9ca554efa43c2491d3af01f63bd5ecee8f" jruby
 
 [essentialkaos]
   package: "jruby-9.3.14.0" "https://ruby.kaos.st/jruby-9.3.14.0.tzst" "37745e5c97d559ac7ea5d89adcf411c4f037179c" jruby

--- a/SOURCES/defs/jruby-9.3.15.0
+++ b/SOURCES/defs/jruby-9.3.15.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.15.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.15.0/jruby-bin-9.3.15.0.tar.gz" "49398d2217a90fdb3d6a124a1198295c3c70126f" jruby
+  package: "jruby-9.3.15.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.15.0/jruby-bin-9.3.15.0.tar.gz" "49398d2217a90fdb3d6a124a1198295c3c70126f" jruby
 
 [essentialkaos]
   package: "jruby-9.3.15.0" "https://ruby.kaos.st/jruby-9.3.15.0.tzst" "371c1cc33ad0afcda951ff07f91246f92c25d4ae" jruby

--- a/SOURCES/defs/jruby-9.3.2.0
+++ b/SOURCES/defs/jruby-9.3.2.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.2.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.2.0/jruby-bin-9.3.2.0.tar.gz" "c01175b959753883fa0dc6a73d9efa2c9eec4465" jruby
+  package: "jruby-9.3.2.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.2.0/jruby-bin-9.3.2.0.tar.gz" "c01175b959753883fa0dc6a73d9efa2c9eec4465" jruby
 
 [essentialkaos]
   package: "jruby-9.3.2.0" "https://ruby.kaos.st/jruby-9.3.2.0.tzst" "af61cd904947d4ea19899478fef261c18cf83653" jruby

--- a/SOURCES/defs/jruby-9.3.3.0
+++ b/SOURCES/defs/jruby-9.3.3.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.3.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.3.0/jruby-bin-9.3.3.0.tar.gz" "3d65f3afe9e811372e402ea81060d00cd950ca3f" jruby
+  package: "jruby-9.3.3.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.3.0/jruby-bin-9.3.3.0.tar.gz" "3d65f3afe9e811372e402ea81060d00cd950ca3f" jruby
 
 [essentialkaos]
   package: "jruby-9.3.3.0" "https://ruby.kaos.st/jruby-9.3.3.0.tzst" "39298898bfbbb2cf3cfd87d536569b0abacf01e9" jruby

--- a/SOURCES/defs/jruby-9.3.4.0
+++ b/SOURCES/defs/jruby-9.3.4.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.4.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.4.0/jruby-bin-9.3.4.0.tar.gz" "91e54b1c8962dd7a7fbcbab012f5d8ba1f15e5a4" jruby
+  package: "jruby-9.3.4.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.4.0/jruby-bin-9.3.4.0.tar.gz" "91e54b1c8962dd7a7fbcbab012f5d8ba1f15e5a4" jruby
 
 [essentialkaos]
   package: "jruby-9.3.4.0" "https://ruby.kaos.st/jruby-9.3.4.0.tzst" "8bd407ed268be4b3db97bdb1652f58376d33122b" jruby

--- a/SOURCES/defs/jruby-9.3.5.0
+++ b/SOURCES/defs/jruby-9.3.5.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.5.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.5.0/jruby-bin-9.3.5.0.tar.gz" "1a696dd723b0bf098bc9e1483e915a7cef01c38f" jruby
+  package: "jruby-9.3.5.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.5.0/jruby-bin-9.3.5.0.tar.gz" "1a696dd723b0bf098bc9e1483e915a7cef01c38f" jruby
 
 [essentialkaos]
   package: "jruby-9.3.5.0" "https://ruby.kaos.st/jruby-9.3.5.0.tzst" "fa7d6338d388f76fcaf757fd9058c1c656f5b3ba" jruby

--- a/SOURCES/defs/jruby-9.3.6.0
+++ b/SOURCES/defs/jruby-9.3.6.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.6.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.6.0/jruby-bin-9.3.6.0.tar.gz" "aefb8a4b564f4f5d6d79b5650fd32bbf91491cd4" jruby
+  package: "jruby-9.3.6.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.6.0/jruby-bin-9.3.6.0.tar.gz" "aefb8a4b564f4f5d6d79b5650fd32bbf91491cd4" jruby
 
 [essentialkaos]
   package: "jruby-9.3.6.0" "https://ruby.kaos.st/jruby-9.3.6.0.tzst" "7bf1ddc044ac654e064969c51fa3fa870ad836fd" jruby

--- a/SOURCES/defs/jruby-9.3.7.0
+++ b/SOURCES/defs/jruby-9.3.7.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.7.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.7.0/jruby-bin-9.3.7.0.tar.gz" "51302029619bc39797b8d5fed5fa1919826b114e" jruby
+  package: "jruby-9.3.7.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.7.0/jruby-bin-9.3.7.0.tar.gz" "51302029619bc39797b8d5fed5fa1919826b114e" jruby
 
 [essentialkaos]
   package: "jruby-9.3.7.0" "https://ruby.kaos.st/jruby-9.3.7.0.tzst" "bc4e394dbc2d3da29485a000a5c9d8cf71ef616f" jruby

--- a/SOURCES/defs/jruby-9.3.8.0
+++ b/SOURCES/defs/jruby-9.3.8.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.8.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.8.0/jruby-bin-9.3.8.0.tar.gz" "9d90cce8ab9d406cdea5db81b28d630113190d88" jruby
+  package: "jruby-9.3.8.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.8.0/jruby-bin-9.3.8.0.tar.gz" "9d90cce8ab9d406cdea5db81b28d630113190d88" jruby
 
 [essentialkaos]
   package: "jruby-9.3.8.0" "https://ruby.kaos.st/jruby-9.3.8.0.tzst" "4b7b0b18db9639cbd385982da018dc8f515360ec" jruby

--- a/SOURCES/defs/jruby-9.3.9.0
+++ b/SOURCES/defs/jruby-9.3.9.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.3.9.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.9.0/jruby-bin-9.3.9.0.tar.gz" "a6dd8493fbf55549b1af35986deb22155b8a47ab" jruby
+  package: "jruby-9.3.9.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.9.0/jruby-bin-9.3.9.0.tar.gz" "a6dd8493fbf55549b1af35986deb22155b8a47ab" jruby
 
 [essentialkaos]
   package: "jruby-9.3.9.0" "https://ruby.kaos.st/jruby-9.3.9.0.tzst" "22e1ef31685519d3f0651678a4b27be0797f01bf" jruby

--- a/SOURCES/defs/jruby-9.4.0.0
+++ b/SOURCES/defs/jruby-9.4.0.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.4.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.4.0.0/jruby-bin-9.4.0.0.tar.gz" "8b2c9824bb5d544bb282fcd1e1e1b3bf416e650d" jruby
+  package: "jruby-9.4.0.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.0.0/jruby-bin-9.4.0.0.tar.gz" "8b2c9824bb5d544bb282fcd1e1e1b3bf416e650d" jruby
 
 [essentialkaos]
   package: "jruby-9.4.0.0" "https://ruby.kaos.st/jruby-9.4.0.0.tzst" "22c5ac78ae77436729c8934ac2783376e12ded15" jruby

--- a/SOURCES/defs/jruby-9.4.1.0
+++ b/SOURCES/defs/jruby-9.4.1.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.4.1.0" "https://s3.amazonaws.com/jruby.org/downloads/9.4.1.0/jruby-bin-9.4.1.0.tar.gz" "7ce36cde5dc3d8ce5677e84a3f233aba767faefa" jruby
+  package: "jruby-9.4.1.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.1.0/jruby-bin-9.4.1.0.tar.gz" "7ce36cde5dc3d8ce5677e84a3f233aba767faefa" jruby
 
 [essentialkaos]
   package: "jruby-9.4.1.0" "https://ruby.kaos.st/jruby-9.4.1.0.tzst" "4f42b0dafd83862d56751ee98d2d1c1ff0170017" jruby

--- a/SOURCES/defs/jruby-9.4.10.0
+++ b/SOURCES/defs/jruby-9.4.10.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.4.10.0" "https://s3.amazonaws.com/jruby.org/downloads/9.4.10.0/jruby-bin-9.4.10.0.tar.gz" "660b24d84412cdbd719690ac54213abce598aadc" jruby
+  package: "jruby-9.4.10.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.10.0/jruby-bin-9.4.10.0.tar.gz" "660b24d84412cdbd719690ac54213abce598aadc" jruby
 
 [essentialkaos]
   package: "jruby-9.4.10.0" "https://ruby.kaos.st/jruby-9.4.10.0.tzst" "512e94fb2b6e6eb0796e4ad8c41be7cea8d830a4" jruby

--- a/SOURCES/defs/jruby-9.4.11.0
+++ b/SOURCES/defs/jruby-9.4.11.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.4.11.0" "https://s3.amazonaws.com/jruby.org/downloads/9.4.11.0/jruby-bin-9.4.11.0.tar.gz" "a5250641b1247596924820d36421cd7fb77b95a5" jruby
+  package: "jruby-9.4.11.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.11.0/jruby-bin-9.4.11.0.tar.gz" "a5250641b1247596924820d36421cd7fb77b95a5" jruby
 
 [essentialkaos]
   package: "jruby-9.4.11.0" "https://ruby.kaos.st/jruby-9.4.11.0.tzst" "ec9a1e532f6701a966d37c368d334b61369b14d3" jruby

--- a/SOURCES/defs/jruby-9.4.12.0
+++ b/SOURCES/defs/jruby-9.4.12.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.4.12.0" "https://s3.amazonaws.com/jruby.org/downloads/9.4.12.0/jruby-bin-9.4.12.0.tar.gz" "d6fb8647ae350083013ebeb8111e142bbc9305be" jruby
+  package: "jruby-9.4.12.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.12.0/jruby-bin-9.4.12.0.tar.gz" "d6fb8647ae350083013ebeb8111e142bbc9305be" jruby
 
 [essentialkaos]
   package: "jruby-9.4.12.0" "https://ruby.kaos.st/jruby-9.4.12.0.tzst" "372a984fcb1aae15c307fb40d795e17fa459d9c4" jruby

--- a/SOURCES/defs/jruby-9.4.2.0
+++ b/SOURCES/defs/jruby-9.4.2.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.4.2.0" "https://s3.amazonaws.com/jruby.org/downloads/9.4.2.0/jruby-bin-9.4.2.0.tar.gz" "c338c1d3846e51b651e31e248097fdee4920056a" jruby
+  package: "jruby-9.4.2.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.2.0/jruby-bin-9.4.2.0.tar.gz" "c338c1d3846e51b651e31e248097fdee4920056a" jruby
 
 [essentialkaos]
   package: "jruby-9.4.2.0" "https://ruby.kaos.st/jruby-9.4.2.0.tzst" "31151ea3cc90c83d8e229d77c32b928099c2c168" jruby

--- a/SOURCES/defs/jruby-9.4.3.0
+++ b/SOURCES/defs/jruby-9.4.3.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.4.3.0" "https://s3.amazonaws.com/jruby.org/downloads/9.4.3.0/jruby-bin-9.4.3.0.tar.gz" "41c683cb5c493c7bda937527611a23a8e60677f0" jruby
+  package: "jruby-9.4.3.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.3.0/jruby-bin-9.4.3.0.tar.gz" "41c683cb5c493c7bda937527611a23a8e60677f0" jruby
 
 [essentialkaos]
   package: "jruby-9.4.3.0" "https://ruby.kaos.st/jruby-9.4.3.0.tzst" "d479316bf1bdc198817817e01ffe8c344274318b" jruby

--- a/SOURCES/defs/jruby-9.4.4.0
+++ b/SOURCES/defs/jruby-9.4.4.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.4.4.0" "https://s3.amazonaws.com/jruby.org/downloads/9.4.4.0/jruby-bin-9.4.4.0.tar.gz" "91215f823196a01173b54b2726ef97fbf084dcee" jruby
+  package: "jruby-9.4.4.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.4.0/jruby-bin-9.4.4.0.tar.gz" "91215f823196a01173b54b2726ef97fbf084dcee" jruby
 
 [essentialkaos]
   package: "jruby-9.4.4.0" "https://ruby.kaos.st/jruby-9.4.4.0.tzst" "5c517981006564e34985cc0f222b6b3a7dd9e3bf" jruby

--- a/SOURCES/defs/jruby-9.4.5.0
+++ b/SOURCES/defs/jruby-9.4.5.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.4.5.0" "https://s3.amazonaws.com/jruby.org/downloads/9.4.5.0/jruby-bin-9.4.5.0.tar.gz" "9f2d039c975659a641d5002d0999aec73b963260" jruby
+  package: "jruby-9.4.5.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.5.0/jruby-bin-9.4.5.0.tar.gz" "9f2d039c975659a641d5002d0999aec73b963260" jruby
 
 [essentialkaos]
   package: "jruby-9.4.5.0" "https://ruby.kaos.st/jruby-9.4.5.0.tzst" "9e4917f4a47c63917ff7e515f57a4943c8e77047" jruby

--- a/SOURCES/defs/jruby-9.4.6.0
+++ b/SOURCES/defs/jruby-9.4.6.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.4.6.0" "https://s3.amazonaws.com/jruby.org/downloads/9.4.6.0/jruby-bin-9.4.6.0.tar.gz" "871d520c9f2494ca56138200c6b2a95c54d0a639" jruby
+  package: "jruby-9.4.6.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.6.0/jruby-bin-9.4.6.0.tar.gz" "871d520c9f2494ca56138200c6b2a95c54d0a639" jruby
 
 [essentialkaos]
   package: "jruby-9.4.6.0" "https://ruby.kaos.st/jruby-9.4.6.0.tzst" "f1094532de485bdba0eea4b1b16e55f49b3ed6da" jruby

--- a/SOURCES/defs/jruby-9.4.7.0
+++ b/SOURCES/defs/jruby-9.4.7.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.4.7.0" "https://s3.amazonaws.com/jruby.org/downloads/9.4.7.0/jruby-bin-9.4.7.0.tar.gz" "ea3b99edcb48ed436173977551a113759541c18c" jruby
+  package: "jruby-9.4.7.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.7.0/jruby-bin-9.4.7.0.tar.gz" "ea3b99edcb48ed436173977551a113759541c18c" jruby
 
 [essentialkaos]
   package: "jruby-9.4.7.0" "https://ruby.kaos.st/jruby-9.4.7.0.tzst" "e9bef381bc8a61aadd72ce951c5992e40f59d4e6" jruby

--- a/SOURCES/defs/jruby-9.4.8.0
+++ b/SOURCES/defs/jruby-9.4.8.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.4.8.0" "https://s3.amazonaws.com/jruby.org/downloads/9.4.8.0/jruby-bin-9.4.8.0.tar.gz" "57089c106c6d0ad09a00db519ab1e984ea716d13" jruby
+  package: "jruby-9.4.8.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.8.0/jruby-bin-9.4.8.0.tar.gz" "57089c106c6d0ad09a00db519ab1e984ea716d13" jruby
 
 [essentialkaos]
   package: "jruby-9.4.8.0" "https://ruby.kaos.st/jruby-9.4.8.0.tzst" "19ead56fd932fc4a4c6a06048f3da6dd8a3444d0" jruby

--- a/SOURCES/defs/jruby-9.4.9.0
+++ b/SOURCES/defs/jruby-9.4.9.0
@@ -6,7 +6,7 @@ deps(deb): make gcc build-essentials
 deps(bin): java
 
 [default]
-  package: "jruby-9.4.9.0" "https://s3.amazonaws.com/jruby.org/downloads/9.4.9.0/jruby-bin-9.4.9.0.tar.gz" "64d8ea53d3ef7637069637f6affa2e7d971c0ade" jruby
+  package: "jruby-9.4.9.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.9.0/jruby-bin-9.4.9.0.tar.gz" "64d8ea53d3ef7637069637f6affa2e7d971c0ade" jruby
 
 [essentialkaos]
   package: "jruby-9.4.9.0" "https://ruby.kaos.st/jruby-9.4.9.0.tzst" "14c5fcfac3e544f3961f94d0cf7fdd1b31ba4ada" jruby

--- a/SOURCES/defs/truffleruby-24.2.1
+++ b/SOURCES/defs/truffleruby-24.2.1
@@ -1,0 +1,11 @@
+# -- [RBdef] --
+# UPDATED 22/Aug/2025 15:18:18 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): gcc openssl-devel
+deps(deb): gcc libssl-dev
+
+[default]
+  package: "truffleruby-24.2.1" "https://github.com/oracle/truffleruby/releases/download/graal-24.2.1/truffleruby-24.2.1-linux-amd64.tar.gz" "7764e2014561ca7a8fa9fcc1cb9fa575a045c946" truffle
+
+[essentialkaos]
+  package: "truffleruby-24.2.1" "https://ruby.kaos.st/truffleruby-24.2.1.tzst" "2d7cccdc9d5b78a77240aed80f35ef78aa5ca515" truffle

--- a/SOURCES/defs/truffleruby-24.2.2
+++ b/SOURCES/defs/truffleruby-24.2.2
@@ -1,0 +1,11 @@
+# -- [RBdef] --
+# UPDATED 22/Aug/2025 15:18:18 by Anton Novojilov <andy@essentialkaos.com>
+
+deps(rpm): gcc openssl-devel
+deps(deb): gcc libssl-dev
+
+[default]
+  package: "truffleruby-24.2.2" "https://github.com/oracle/truffleruby/releases/download/graal-24.2.2/truffleruby-24.2.2-linux-amd64.tar.gz" "d8fdff0bd117d38cd8ff5a3552b141b27bfabf54" truffle
+
+[essentialkaos]
+  package: "truffleruby-24.2.2" "https://ruby.kaos.st/truffleruby-24.2.2.tzst" "0016393c7258069b19dc59d3424c8ed704c2ae2a" truffle

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -2,7 +2,7 @@
 
 Summary:    Def files for rbbuild utility
 Name:       rbbuild-defs
-Version:    2.0.12
+Version:    2.0.13
 Release:    0%{?dist}
 License:    Apache License, Version 2.0
 Vendor:     ESSENTIAL KAOS
@@ -51,6 +51,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 15 2025 Anton Novojilov <andy@essentialkaos.com> - 2.0.13-0
+- Added jruby-10.0.0.0
+
 * Mon Apr 14 2025 Anton Novojilov <andy@essentialkaos.com> - 2.0.12-0
 - Added 3.1.7
 - Added 3.1.7-jemalloc

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -68,6 +68,7 @@ rm -rf %{buildroot}
 - Added truffleruby-24.2.1
 - Added truffleruby-24.2.2
 - Updated URL of source for all jruby defs
+- OpenSSL updated to 3.0.17 for 3.1.0+
 
 * Tue Apr 15 2025 Anton Novojilov <andy@essentialkaos.com> - 2.0.13-0
 - Added jruby-10.0.0.0

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -52,9 +52,21 @@ rm -rf %{buildroot}
 
 %changelog
 * Fri Aug 22 2025 Anton Novojilov <andy@essentialkaos.com> - 2.1.0-0
+- Added 3.2.9
+- Added 3.2.9-jemalloc
+- Added 3.3.9
+- Added 3.3.9-jemalloc
+- Added 3.4.3
+- Added 3.4.3-jemalloc
+- Added 3.4.4
+- Added 3.4.4-jemalloc
+- Added 3.4.5
+- Added 3.4.5-jemalloc
 - Added jruby-10.0.0.1
 - Added jruby-10.0.1.0
 - Added jruby-10.0.2.0
+- Added truffleruby-24.2.1
+- Added truffleruby-24.2.2
 - Updated URL of source for all jruby defs
 
 * Tue Apr 15 2025 Anton Novojilov <andy@essentialkaos.com> - 2.0.13-0

--- a/rbbuild-defs.spec
+++ b/rbbuild-defs.spec
@@ -2,7 +2,7 @@
 
 Summary:    Def files for rbbuild utility
 Name:       rbbuild-defs
-Version:    2.0.13
+Version:    2.1.0
 Release:    0%{?dist}
 License:    Apache License, Version 2.0
 Vendor:     ESSENTIAL KAOS
@@ -51,6 +51,12 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Fri Aug 22 2025 Anton Novojilov <andy@essentialkaos.com> - 2.1.0-0
+- Added jruby-10.0.0.1
+- Added jruby-10.0.1.0
+- Added jruby-10.0.2.0
+- Updated URL of source for all jruby defs
+
 * Tue Apr 15 2025 Anton Novojilov <andy@essentialkaos.com> - 2.0.13-0
 - Added jruby-10.0.0.0
 

--- a/rbbuild.spec
+++ b/rbbuild.spec
@@ -15,7 +15,7 @@ BuildArch:  noarch
 BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 Requires:   %{name}-defs >= 2
-Requires:   bash zstd patch gawk bc git
+Requires:   bash curl zstd patch gawk bc git
 
 Provides:   %{name} = %{version}-%{release}
 


### PR DESCRIPTION
### New
- Added 3.2.9
- Added 3.2.9-jemalloc
- Added 3.3.9
- Added 3.3.9-jemalloc
- Added 3.4.3
- Added 3.4.3-jemalloc
- Added 3.4.4
- Added 3.4.4-jemalloc
- Added 3.4.5
- Added 3.4.5-jemalloc
- Added jruby-10.0.0.1
- Added jruby-10.0.1.0
- Added jruby-10.0.2.0
- Added truffleruby-24.2.1
- Added truffleruby-24.2.2

### Improvements
- Updated URL of source for all JRuby defs
- OpenSSL updated to 3.0.17 for 3.1.0+
- Added Dockerfiles for build nodes